### PR TITLE
Play code of conduct

### DIFF
--- a/app/assets/css/pages/_conduct.styl
+++ b/app/assets/css/pages/_conduct.styl
@@ -1,0 +1,4 @@
+.conduct
+    @extend .content-column
+    article
+        color: black

--- a/app/assets/css/pages/_index.styl
+++ b/app/assets/css/pages/_index.styl
@@ -7,4 +7,5 @@
 @import "_modules.styl"
 @import "_support.styl"
 @import "_changelog.styl"
+@import "_conduct.styl"
 @import "_security.styl"

--- a/app/views/commonSidebar.scala.html
+++ b/app/views/commonSidebar.scala.html
@@ -17,6 +17,7 @@
 <@hn>Contribute</@hn>
 <ul>
     <li><a href="@routes.Code.index()">Code and contributors</a></li>
+    <li><a href="@routes.Application.conduct()">Code of conduct</a></li>
     <li><a href="@routes.Application.getInvolved()">Get involved</a></li>
     <li><a href="@routes.Security.index()">Reporting security vulnerabilities</a></li>
 </ul>

--- a/app/views/conduct.scala.html
+++ b/app/views/conduct.scala.html
@@ -1,0 +1,18 @@
+@(markdown: Html)(implicit requestHeader : RequestHeader)
+
+@main("Play code of conduct", "conduct"){
+    <header id="top">
+        <div class="wrapper">
+            <h1>Code of conduct</h1>
+        </div>
+    </header>
+    <section id="content">
+        <article>
+            @markdown
+        </article>
+        <aside>
+            @commonSidebar()
+        </aside>
+    </section>
+    @prettify()
+}

--- a/conf/routes
+++ b/conf/routes
@@ -13,6 +13,7 @@ GET         /code                                                    controllers
 GET         /get-involved                                            controllers.Application.getInvolved
 GET         /widget                                                  controllers.Application.widget(version: Option[String] ?= None)
 GET         /changelog                                               controllers.Application.changelog
+GET         /conduct                                                 controllers.Application.conduct
 
 POST        /preferredLang/:lang                                     controllers.Application.setPreferedLanguage(lang)
 

--- a/public/markdown/code-of-conduct.md
+++ b/public/markdown/code-of-conduct.md
@@ -1,0 +1,37 @@
+# Code of Conduct
+
+*Published 15 December 2014 (v1.0)*
+
+This Code of Conduct governs how we behave in any forum and whenever we will be judged by our actions. We expect it to be honored by everyone who represents the Play community officially or informally, claims affiliation with the project or participates directly.
+
+We strive to:
+
+* **Be open**: We invite anybody, from any company, to participate in any aspect of our projects. Our community is open, and any responsibility can be carried by any contributor who demonstrates the required capacity and competence.
+* **Be empathetic**: We work together to resolve conflict, assume good intentions and do our best to act in an empathic fashion. We don't allow frustration to turn into a personal attack. A community where people feel uncomfortable or threatened is not a productive one.
+* **Be collaborative**: Collaboration reduces redundancy and improves the quality of our work. We prefer to work transparently and involve interested parties as early as possible. Wherever possible, we work closely with upstream projects and others in the free software community to coordinate our efforts.
+* **Be inquisitive**: Nobody knows everything, asking questions early avoids many problems later, so questions are encouraged, though they may be directed to the appropriate forum. Those who are asked should be responsive and helpful.
+* **Step down considerately**: Members of every project come and go. When somebody leaves or disengages from the project they should tell people they are leaving and take the proper steps to ensure that others can pick up where they left off.
+
+This code is not exhaustive or complete. It serves to distill our common understanding of a collaborative, shared environment and goals. We expect it to be followed in spirit as much as in the letter.
+
+## Diversity Statement
+
+We encourage participation by everyone. We are committed to being a community that everyone feels good about joining. Although we may not be able to satisfy everyone, we will always work to treat everyone well.
+
+Standards for behavior in the Play community are detailed in the Code of Conduct above. We expect participants in our community to meet these standards in all their interactions and to help others to do so as well.
+
+Whenever any participant has made a mistake, we expect them to take responsibility for it. If someone has been harmed or offended, it is our responsibility to listen carefully and respectfully, and do our best to right the wrong.
+
+Although this list cannot be exhaustive, we explicitly honor diversity in age, culture, ethnicity, genotype, gender identity or expression, language, national origin, neurotype, phenotype, political beliefs, profession, race, religion, sexual orientation, socioeconomic status, subculture and technical ability.
+
+## Reporting Issues
+
+We recommend you first speak with respective project leads and committers about the issue.
+
+If that doesn't work, or if you want to report issues privately, please fill out the [contact owner](https://groups.google.com/forum/#!contactowner/play-framework) form for the Play mailing list.
+
+## Thanks
+
+Some of the ideas and wording for the statements above were based on work by the [Python](http://www.python.org/community/diversity), [Ubuntu](http://www.ubuntu.com/about/about-ubuntu/conduct), [Mozilla](https://wiki.mozilla.org/Code_of_Conduct/Draft) and [TwitterOSS](https://engineering.twitter.com/opensource/code-of-conduct) communities. We are thankful for their work.
+
+*The Play of Conduct is licensed under the [Creative Commons Attribution-Share Alike 3.0 license](http://creativecommons.org/licenses/by-sa/3.0/). You may re-use it for your own project, and modify it as you wish, just please allow others to use your modifications and give credit to Play and other communities listed above.*


### PR DESCRIPTION
This PR represents a draft code of conduct as well as the infrastructure necessary to include it in the Play website.

The draft code of conduct has been copied primarily from the TwitterOSS code of conduct.  It is essentially unchanged from that, except for updating it to refer to the Play project and procedures.  I chose to start with the TwitterOSS code of conduct because it's quite concise yet comprehensive.
