### PR TITLE
* fix(module): on module documentation, the menu appear on the bottom of...

### DIFF
--- a/app/views/modules/documentation.scala.html
+++ b/app/views/modules/documentation.scala.html
@@ -9,11 +9,7 @@
     </section>
     
     <div id="content" class="wrapper">
-        <article>
-            @Html(content)
-        </article>
-        <aside>
-            
+        <aside>    
             <h3>Browse</h3>
             <ul>
                 <li><a href="@routes.Modules.show(module)">Back to module description</a></li>
@@ -24,6 +20,9 @@
             <div id="toc"></div>
             
         </aside>
+        <article>
+            @Html(content)
+        </article>
     </div>
     
     <script type="text/javascript" src="@routes.Assets.versioned("javascripts/modules/navigation.js")" charset="utf-8"></script>

--- a/app/views/modules/layout.scala.html
+++ b/app/views/modules/layout.scala.html
@@ -9,13 +9,6 @@
     </section>
     
     <div id="content" class="wrapper">
-        
-        <article>
-            
-            @content
-            
-        </article>
-        
         <aside>
             <h3>Selected modules</h3>
             <ul>
@@ -29,7 +22,9 @@
                 <li><a href="@routes.Modules.show("search")">Simple search</a></li>
             </ul>
         </aside>
-        
+        <article> 
+            @content   
+        </article>  
     </div>
     
 }


### PR DESCRIPTION
... the page. Fix the layout to display the navigation menu on the top right

The page navigation menu on the right column is displayed on the page bottom.

Problem can be see on page : 
* https://www.playframework.com/modules
* https://www.playframework.com/modules/excel
* https://www.playframework.com/modules/excel-1.2.3/home


