### PR TITLE
Added ability to name releases

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -35,7 +35,7 @@ class Application @Inject() (
       } finally {
         is.close()
       }
-    }.getOrElse(PlayReleases(PlayRelease("unknown", None, Some("unknown"), None), Nil, Nil))
+    }.getOrElse(PlayReleases(PlayRelease("unknown", None, Some("unknown"), None, None), Nil, Nil))
   }
 
   private val VulnerableVersions = Set(
@@ -61,10 +61,8 @@ class Application @Inject() (
   }
 
 
-  def index = Action.async { implicit request =>
-    latestActivator.map { activator =>
-      Ok(html.index(activator))
-    }
+  def index = Action { implicit request =>
+    Ok(html.index(releases))
   }
 
   def widget(version: Option[String]) = Action { request =>

--- a/app/models/Releases.scala
+++ b/app/models/Releases.scala
@@ -2,7 +2,7 @@ package models
 
 import play.api.libs.json.Json
 
-case class PlayRelease(version: String, url: Option[String], date: Option[String], size: Option[String])
+case class PlayRelease(version: String, url: Option[String], date: Option[String], size: Option[String], name: Option[String])
 
 object PlayRelease {
   implicit val releaseReads = Json.reads[PlayRelease]

--- a/app/views/download.scala.html
+++ b/app/views/download.scala.html
@@ -36,7 +36,7 @@
     <section  id="content">
         <div class="downloads">
             <div class="latest">
-                <h2><a href="@activator.miniUrl" class="cover downloadActivatorLink" data-version="minimal"/>Download Play @activator.playVersion</a></h2>
+                <h2><a href="@activator.miniUrl" class="cover downloadActivatorLink" data-version="minimal"/>Download Play @releases.latest.version@for(name <- releases.latest.name){ "@name"}</a></h2>
                 <p>including Activator @activator.version</p>
                 <p>1MB - Windows, Mac and Linux - JDK6+</p>
             </div>
@@ -59,9 +59,6 @@
                 </div>
             </div>
         </div>
-        <p class="deprecated">
-            The former 'play' command has been replaced by a more general '<code>activator</code>' command. <a href="//groups.google.com/d/msg/play-framework/bTvJbeR_zvU/J3reqk6Xo4AJ">Read the announcement</a>.
-        </p>
 
         <article class="activator">
             <h2>Play with Activator</h2>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,4 +1,4 @@
-@(activator: ActivatorRelease, title: String = "Play Framework - Build Modern & Scalable Web Apps with Java and Scala")(implicit requestHeader : RequestHeader)
+@(releases: PlayReleases, title: String = "Play Framework - Build Modern & Scalable Web Apps with Java and Scala")(implicit requestHeader : RequestHeader)
 
 @main(title) {
     <header id="top">
@@ -13,7 +13,7 @@
     <section id="content">
         <div id="start">
             <h2>Get the latest package</h2>
-                <a href="@routes.Application.download()" class="download">Download @activator.playVersion</a>
+                <a href="@routes.Application.download()" class="download">Download @releases.latest.version@for(name <- releases.latest.name){ "@name"}</a>
             <p>
                 or <a href="@routes.Application.download()#older-versions">browse all versions</a>
             </p>


### PR DESCRIPTION
Modified the index page and the downloads page. One consequence of this is that we no longer get the most recent Play version from Activator, which I don't think ever made sense anyway.

See screenshots:

![index](https://cloud.githubusercontent.com/assets/105833/7826601/bee6a948-045f-11e5-8582-9aa9cf713eb5.png)

![download](https://cloud.githubusercontent.com/assets/105833/7826602/c1725aa4-045f-11e5-806c-290090e1e5ad.png)
