### PR TITLE
set changed lang in cookie

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -144,8 +144,12 @@ class Application @Inject() (
     }
   }
 
-  def setPreferedLanguage(lang: String) = Action {
-    messagesApi.setLang(Ok, Lang(lang))
+  def setPreferedLanguage(lang: String, path: String) = Action {
+    if (path.startsWith("/")) {
+      messagesApi.setLang(Redirect(path, SEE_OTHER), Lang(lang))
+    } else {
+      BadRequest
+    }
   }
 
 }

--- a/app/views/documentation/nav.scala.html
+++ b/app/views/documentation/nav.scala.html
@@ -2,9 +2,15 @@
 
 @language(lang: Lang, isDefault: Boolean, version: Option[models.documentation.Version]) = {
     <a href="@version.fold(
-        controllers.documentation.ReverseRouter.latest(Some(lang).filterNot(_ => isDefault))
+        routes.Application.setPreferedLanguage(
+          lang.language,
+          controllers.documentation.ReverseRouter.latest(Some(lang).filterNot(_ => isDefault))
+        )
     )( v =>
-        controllers.documentation.ReverseRouter.page(Some(lang).filterNot(_ => isDefault), v.name, page)
+        routes.Application.setPreferedLanguage(
+          lang.language,
+          controllers.documentation.ReverseRouter.page(Some(lang).filterNot(_ => isDefault), v.name, page)
+        )
     )">@messages("lang.name")(lang)</a>
 }
 

--- a/conf/routes
+++ b/conf/routes
@@ -22,7 +22,7 @@ POST        /certification/interest                                  controllers
 GET         /outreachy                                               controllers.Outreachy.outreachy
 GET         /outreachy/round10                                       controllers.Outreachy.round10
 
-POST        /preferredLang/:lang                                     controllers.Application.setPreferedLanguage(lang)
+GET         /preferredLang/:lang                                     controllers.Application.setPreferedLanguage(lang, path)
 
 # Because I sent the security email with a bad link
 GET         /security/vulnerability/20130920XmlExternalEntity        controllers.Application.movedTo(url="/security/vulnerability/20130920-XmlExternalEntity", originalPath="foo")


### PR DESCRIPTION
Once change the documentation lang, from next time I wanna see changed language documentation again.
(jp latest documentation is still Play2.2, so when click header documentation link, redirect to jp Play2.2 doc anytime)

- `POST /preferred/:lang` is not used(is this true?), so just change a little bit.
- set change lang in cookie based on messageApi interface
- from next time access, if there is no lang info in path, cookie lang is prefer than accept language.
- not to use `GET /preferred/:lang` as open redirector, validate the path parameter is nor external url.