### PR TITLE
Make downloads work when Google Analytics is blocked

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -136,8 +136,7 @@ $(function(){
             getStarted = $(".get-started"),
             getStartedBack = $(".back", getStarted);
 
-        // Trigger after a click and its tracking event have finished
-        download.on('trackedClick', function(e) {
+        download.on('click', function(e) {
             getStarted.show();
         });
         getStartedBack.click(function(e) {
@@ -156,9 +155,11 @@ $(function(){
         });
     })
 
-    // Downloads page tracking
+    // This function handles analytics tracking for certain
+    // download links.
     function trackDownload(selector, name) {
-        $(selector).click(function() {
+        var downloadElements = $(selector);
+        downloadElements.click(function() {
             var el = $(this)
             var version = el.data("version");
             if (version) {
@@ -166,26 +167,13 @@ $(function(){
             } else {
                 var label = name;
             }
-            function triggerTrackedClick() {
-                el.trigger('trackedClick');
-            }
-            if (window._gaq) {
-                _gaq.push(
-                    ["_set", "hitCallback", triggerTrackedClick],
-                    ["_trackEvent", "download", "click", label],
-                    ["_set", "hitCallback", null]
-                );
-            } else {
-                // Trigger tracked click immediately if analytics not loaded
-                triggerTrackedClick();
-            }
-            // Stop download for now because it would prevent tracking
-            return false;
-        });
-        // Resume normal click behavior after tracking has happened.
-        $(selector).on('trackedClick', function() {
-            location.href = $(this).attr('href');
+            _gaq.push(["_trackEvent", "download", "click", label]);
+            return true;
         })
+        // Target downloads at an iframe so they don't unload this
+        // page. Unloading the page can interrupt Google Analytics
+        // and mess up our statistics.
+        downloadElements.attr('target', 'download-iframe');
     }
     trackDownload(".downloadActivatorLink", "activator");
     trackDownload(".downloadStandaloneLink", "standalone");

--- a/app/views/download.scala.html
+++ b/app/views/download.scala.html
@@ -162,4 +162,7 @@
             </ul>
         </div>
     </div>
+
+    <!-- Downloads are targeted at this iframe -->
+    <iframe name="download-iframe" style="display:none" src="data:,">
 }


### PR DESCRIPTION
Previously we tried to detect when Google Analytics was blocked and ran alternative logic. But it turns out to be hard to detect when it's blocked. Detecting presence of the _gaq array can't be relied on, since users are encouraged to create that array if needed (we create the array in two places). Detecting other objects is unreliable since they may not have loaded yet or they may have been replaced by a shim (Ghostery does this).

Instead we take the dumb-but-effective approach of trying to use Google Analytics for up to 3 seconds, but then manually starting the download if we need to. This has the added benefit of handling issues with Google Analytics being slow.

In some cases, i.e. when ads are blocked, this will delay the download from starting. We now show the "Getting started" dialog a bit earlier so that users will know that something is happening, even if it takes
a few seconds to start.