### PR TITLE
Fix mixed content error for downloads

### DIFF
--- a/app/models/Releases.scala
+++ b/app/models/Releases.scala
@@ -2,7 +2,9 @@ package models
 
 import play.api.libs.json.Json
 
-case class PlayRelease(version: String, url: Option[String], date: Option[String], size: Option[String], name: Option[String])
+case class PlayRelease(version: String, private val url: Option[String], date: Option[String], size: Option[String], name: Option[String]) {
+  lazy val secureUrl: Option[String] = url.map(SecurifyUrl.securify)
+}
 
 object PlayRelease {
   implicit val releaseReads = Json.reads[PlayRelease]
@@ -14,9 +16,17 @@ object PlayReleases {
   implicit val playReleasesReads = Json.reads[PlayReleases]
 }
 
-case class ActivatorRelease(version: String, url: String, miniUrl: String, size: String, miniSize: String,
-  playVersion: String, akkaVersion: String, scalaVersion: String)
+case class ActivatorRelease(version: String, private val url: String, private val miniUrl: String, size: String, miniSize: String,
+  playVersion: String, akkaVersion: String, scalaVersion: String) {
+
+  lazy val secureUrl: String = SecurifyUrl.securify(url)
+  lazy val miniSecureUrl: String = SecurifyUrl.securify(miniUrl)
+}
 
 object ActivatorRelease {
   implicit val activatorReads = Json.reads[ActivatorRelease]
+}
+
+private[models] object SecurifyUrl {
+  def securify(url: String): String = url.replaceFirst("http", "https")
 }

--- a/app/views/download.scala.html
+++ b/app/views/download.scala.html
@@ -1,9 +1,9 @@
 @(releases: PlayReleases, activator: ActivatorRelease, platform: Platform.Platform, title: String = "Downloads")(implicit requestHeader : RequestHeader)
 
 @renderRelease(linkClass: String, release: PlayRelease) = {
-    @if(release.url) {
+    @if(release.secureUrl) {
         <td width="250">
-            <a href="@release.url.get" class="@linkClass" data-version="@{release.version}">play-@{release.version}.zip</a>
+            <a href="@release.secureUrl.get" class="@linkClass" data-version="@{release.version}">play-@{release.version}.zip</a>
         </td>
         <td width="200">
             @release.date
@@ -14,7 +14,7 @@
     } else {
         <td width="250">
             Play @release.version
-            <span class="small">(<a href="@activator.miniUrl" class="downloadActivatorLink" data-version="old">activator</a>)</span>
+            <span class="small">(<a href="@activator.miniSecureUrl" class="downloadActivatorLink" data-version="old">activator</a>)</span>
         </td>
         <td width="200">
             @release.date
@@ -36,7 +36,7 @@
     <section  id="content">
         <div class="downloads">
             <div class="latest">
-                <h2><a href="@activator.miniUrl" class="cover downloadActivatorLink" data-version="minimal"/>Download Play @releases.latest.version@for(name <- releases.latest.name){ "@name"}</a></h2>
+                <h2><a href="@activator.miniSecureUrl" class="cover downloadActivatorLink" data-version="minimal"/>Download Play @releases.latest.version@for(name <- releases.latest.name){ "@name"}</a></h2>
                 <p>including Activator @activator.version</p>
                 <p>1MB - Windows, Mac and Linux - JDK8+</p>
             </div>
@@ -44,7 +44,7 @@
                 <div class="cols">
                     <h3>Alternative downloads</h3>
                     <ul>
-                        <li><a href="@activator.url" class="downloadActivatorLink" data-version="offline">Offline Distribution</a> (@activator.size)</li>
+                        <li><a href="@activator.secureUrl" class="downloadActivatorLink" data-version="offline">Offline Distribution</a> (@activator.size)</li>
                         <li><a href="#as-dependency">Play as a dependency</a></li>
                         <li><a href="#older-versions">Older Play releases</a></li>
                     </ul>


### PR DESCRIPTION
Change downloads to use https instead of http. This is probably a better default anyway.