### PR TITLE
Styling for anchor icon

### DIFF
--- a/app/assets/css/modules/_page.styl
+++ b/app/assets/css/modules/_page.styl
@@ -27,6 +27,19 @@
             display: block
             height: 540px
             z-index: -1
+    .section-marker
+        position: absolute
+        width: 1em
+        margin-left: -1em
+        display: block
+        text-decoration: none
+        visibility: hidden
+        text-align: center
+        font-weight: normal
+    h1:hover > a, h2:hover > a, h3:hover > a, h4:hover > a, h5:hover > a
+        visibility: visible
+        color: inherit
+        text-decoration: none        
 
 article, aside
     @extend .typo


### PR DESCRIPTION
This adds CSS styling for the `section-marker` class which is used to create an anchor icon for each headline in the documentation.

The corresponding PR in [play-doc](https://github.com/playframework/play-doc) is [#17](https://github.com/playframework/play-doc/pull/17).