### PR TITLE
Fix open redirect vulnerability in trailing slash removal

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -138,7 +138,7 @@ class Application @Inject() (
 
   def onHandlerNotFound(route: String) = Action { implicit request =>
     if (route.endsWith("/")) {
-      MovedPermanently("//" + request.host + "/" + request.path.take(request.path.length - 1).dropWhile(_ == '/'))
+      MovedPermanently("/" + request.path.take(request.path.length - 1).dropWhile(_ == '/'))
     } else {
       notFound
     }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -138,7 +138,7 @@ class Application @Inject() (
 
   def onHandlerNotFound(route: String) = Action { implicit request =>
     if (route.endsWith("/")) {
-      MovedPermanently(request.path.take(request.path.length - 1))
+      MovedPermanently("//" + request.host + "/" + request.path.take(request.path.length - 1).dropWhile(_ == '/'))
     } else {
       notFound
     }


### PR DESCRIPTION
I found that the Play Framework website allows redirecting to any URL through the trailing slash removal code. This is not a serious security issue because currently there's no members section on the website where the user could enter credentials and generally the audience is well-educated, still it allows phishing attacks by an attacker website appearing trustworthy since the domain name in the link sent to the target user is the trusted playframework.com. That's why it's probably better to fix than to leave it open.

**Proof of concept:**
* [https://playframework.com////evilzone.org/](https://playframework.com////evilzone.org/)
* [https://playframework.com////evilzone.org/hacking-and-security/](https://playframework.com////evilzone.org/hacking-and-security/)
* [https://playframework.com////p1ayframework.com/](https://playframework.com////p1ayframework.com/)