### PR TITLE
Responsive design fixes

### DIFF
--- a/app/assets/css/main.styl
+++ b/app/assets/css/main.styl
@@ -16,6 +16,11 @@ body
     body
         -webkit-text-size-adjust:none
 
+// The ribbon obscures the navigation when there is no rightnav
+@media only screen and (max-width: 960px)
+    #reactive_ribbon
+        display: none
+
 a
     text-decoration: none
 

--- a/app/assets/css/pages/_documentation.styl
+++ b/app/assets/css/pages/_documentation.styl
@@ -235,5 +235,7 @@ hr.clear
                     padding-right: 10px
 
             aside
-                width: auto
-                padding: 0 10px
+                // don't display menus on phones
+                // ideally this would be a slide out menu using Twitter Bootstrap Collapse
+                // like simple_fb_html5_sidebar
+                display: none

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -81,10 +81,10 @@
 
 @*
         @if(requestHeader.session.data.get("github")) {
-            welcome, @requestHeader.session.data("github") 
+            welcome, @requestHeader.session.data("github")
             <img src="@requestHeader.session.data("github_avatar")"></img>
-        } else { 
-          <a href="https://github.com/login/oauth/authorize?client_id=@models.Github.clientId&scope=repo,user">login via Github</a>	
+        } else {
+          <a href="https://github.com/login/oauth/authorize?client_id=@models.Github.clientId&scope=repo,user">login via Github</a>
         }
 *@
 
@@ -152,7 +152,7 @@
             </div>
         </footer>
 
-        <a href="http://www.reactivemanifesto.org/">
+        <a href="http://www.reactivemanifesto.org/" id="reactive_ribbon">
             <img style="border: 0; position: fixed; right: 0; top:0; z-index: 9000"
                 src="//d379ifj7s9wntv.cloudfront.net/reactivemanifesto/images/ribbons/we-are-reactive-black-right.png">
         </a>
@@ -178,7 +178,6 @@
           s.onload = initMunchkin;
           document.getElementsByTagName('head')[0].appendChild(s);
         })();
-        </script>        
+        </script>
     </body>
 </html>
-


### PR DESCRIPTION
On small displays, the banner will obscure the documentation, so add a media query to hide it when the display is small enough.

Also hide the menu "aside" block when on mobile devices, as it's pretty huge.  Technically should be below or a "side swipe" but I lack the expertise to do that.