### PR TITLE
Update pages to use Lightbend instead of Typesafe

### DIFF
--- a/app/actors/ActivatorReleaseActor.scala
+++ b/app/actors/ActivatorReleaseActor.scala
@@ -31,8 +31,8 @@ class ActivatorReleaseActor @Inject() (ws: WSClient, configuration: Configuratio
   def receive = withRelease(
     ActivatorRelease(
       version = "(unknown)",
-      url = "https://typesafe.com/platform/getstarted",
-      miniUrl = "https://typesafe.com/platform/getstarted",
+      url = "https://lightbend.com/platform/getstarted",
+      miniUrl = "https://lightbend.com/platform/getstarted",
       size = "???M",
       miniSize = "?M",
       akkaVersion = "(unknown)",

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -196,7 +196,7 @@ _gaq.push(['_trackPageview']);
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-ga('create', 'UA-23127719-1', 'typesafe.com', {'allowLinker': true, 'name': 'tsTracker'});
+ga('create', 'UA-23127719-1', 'lightbend.com', {'allowLinker': true, 'name': 'tsTracker'});
 ga('require', 'linker');
-ga('linker:autoLink', ['typesafe.com','playframework.com','scala-lang.org','scaladays.org','spray.io','akka.io','scala-sbt.org','scala-ide.org']);
+ga('linker:autoLink', ['lightbend.com','playframework.com','scala-lang.org','scaladays.org','spray.io','akka.io','scala-sbt.org','scala-ide.org']);
 ga('tsTracker.send', 'pageview');

--- a/app/views/commonSidebar.scala.html
+++ b/app/views/commonSidebar.scala.html
@@ -12,7 +12,7 @@
 <ul>
     <li><a href="//groups.google.com/forum/#!forum/play-framework">Mailing list</a></li>
     <li><a href="//stackoverflow.com/questions/tagged/playframework">Stackoverflow</a></li>
-    <li><a href="//typesafe.com/how">Professional support</a></li>
+    <li><a href="//lightbend.com/how">Professional support</a></li>
 </ul>
 <@hn>Contribute</@hn>
 <ul>

--- a/app/views/documentation/v2.scala.html
+++ b/app/views/documentation/v2.scala.html
@@ -12,10 +12,10 @@
 
         <h3>Books</h3>
         <p><a title="Play in Practice" href="http://shop.oreilly.com/product/0636920035718.do"><img src="@routes.Assets.versioned("images/docs/play-in-practice.gif")"/></a></p>
-        <p><a title="Play Framework Essentials" href="http://www.typesafe.com/resources/e-book/play-framework-essentials"><img width="180" height="236" src="@routes.Assets.versioned("images/docs/play-framework-essentials-cover.jpg")"/></a></p>
-        <p><a title="Reactive Web Applications with Play" href="http://info.typesafe.com/EBK-20XX-Reactive-Web-Applications-with-Play_L.html?lst=PPS&lsd=EBK-20XX-Reactive-Web-Applications-with-Play"><img src="@routes.Assets.versioned("images/docs/Reactive-Web-App-with-Play-Cover.jpg")"></a></p>
-        <p><a title="Play for Scala" href="http://typesafe.com/resources/e-book/play-for-scala"><img src="@routes.Assets.versioned("images/docs/play-for-scala-cover.jpg")"></a></p>
-        <p><a title="Play for Java" href="http://typesafe.com/resources/e-book/play-for-java"><img src="@routes.Assets.versioned("images/docs/play-for-java-cover.jpg")"></a></p>
+        <p><a title="Play Framework Essentials" href="http://www.lightbend.com/resources/e-book/play-framework-essentials"><img width="180" height="236" src="@routes.Assets.versioned("images/docs/play-framework-essentials-cover.jpg")"/></a></p>
+        <p><a title="Reactive Web Applications with Play" href="http://info.lightbend.com/EBK-20XX-Reactive-Web-Applications-with-Play_L.html?lst=PPS&lsd=EBK-20XX-Reactive-Web-Applications-with-Play"><img src="@routes.Assets.versioned("images/docs/Reactive-Web-App-with-Play-Cover.jpg")"></a></p>
+        <p><a title="Play for Scala" href="http://lightbend.com/resources/e-book/play-for-scala"><img src="@routes.Assets.versioned("images/docs/play-for-scala-cover.jpg")"></a></p>
+        <p><a title="Play for Java" href="http://lightbend.com/resources/e-book/play-for-java"><img src="@routes.Assets.versioned("images/docs/play-for-java-cover.jpg")"></a></p>
         <p><a title="Learning Play! Framework 2" href="http://www.packtpub.com/learning-play-framework-2/book"><img src="@routes.Assets.versioned("images/docs/learning-play-cover.jpg")"></a></p>
     </aside>
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -73,7 +73,7 @@ sitemapgenerator-dispatcher {
   }
 }
 
-activator.latest-url="https://www.typesafe.com/activator/latest"
+activator.latest-url="https://www.lightbend.com/activator/latest"
 
 documentation {
   path = "."

--- a/public/markdown/community-process.md
+++ b/public/markdown/community-process.md
@@ -9,13 +9,13 @@ The goal of this page is to increase community contribution and sense of ownersh
 
 ## Project ownership
 
-The Play project source code is owned and licensed by [Typesafe](https://www.typesafe.com).  Typesafe employees a team of developers who work on Play full time, and has the final say on both product decisions and technical decisions for the project.
+The Play project source code is owned and licensed by [Lightbend](https://www.lightbend.com).  Lightbend employees a team of developers who work on Play full time, and has the final say on both product decisions and technical decisions for the project.
 
-Though Typesafe wholly owns the Play project and has the final say in any decisions made, Typesafe does not own the Play community, nor does Typesafe take for granted its existence.  The Play community is arguably just as important, if not more important, than the Play project itself.  With over 400 community contributors to the core of Play, and hundreds more to the broader Play ecosystem, the Play community could easily survive without or in spite of Typesafe, if it ever came to that.
+Though Lightbend wholly owns the Play project and has the final say in any decisions made, Lightbend does not own the Play community, nor does Lightbend take for granted its existence.  The Play community is arguably just as important, if not more important, than the Play project itself.  With over 400 community contributors to the core of Play, and hundreds more to the broader Play ecosystem, the Play community could easily survive without or in spite of Lightbend, if it ever came to that.
 
-For this reason, Typesafe's relationship to the Play project is best described as a stewardship, Typesafe manages the Play project, but is held accountable by the Play community.
+For this reason, Lightbend's relationship to the Play project is best described as a stewardship, Lightbend manages the Play project, but is held accountable by the Play community.
 
-For a statement of how Typesafe views open source, see the [Typesafe Open Source Position Statement](http://typesafe.com/open-source-position-statement).
+For a statement of how Lightbend views open source, see the [Lightbend Open Source Position Statement](http://lightbend.com/open-source-position-statement).
 
 ## Definitions
 
@@ -67,18 +67,18 @@ Whether a pull request is merged or not depends on many factors, including:
 
 The primary place for discussion about the design of Play and how the Play project is run is the [play-framework-dev](https://groups.google.com/forum/#!forum/play-framework-dev) mailing list.  All major new features, refactorings or changes to the project should first be discussed in this forum.  The aim of the discussions is to reach an understanding on whether the task will be done, and how it will be done.  When a new topic is posted, interested parties are encouraged to comment with their affirmation or concerns.
 
-While Typesafe ultimately has the last word on all decisions here, as much as possible we will endeavor to reach a consensus in the majority of the community.
+While Lightbend ultimately has the last word on all decisions here, as much as possible we will endeavor to reach a consensus in the majority of the community.
 
 ## Integrator selection
 
-Integrator selection is made by Typesafe.  Typesafe will offer contributors integrator status based on the following criteria:
+Integrator selection is made by Lightbend.  Lightbend will offer contributors integrator status based on the following criteria:
 
 * The contributor has made substantial contributions to Play.  What makes a substantial contribution is subjective, but for example, recent new integrators have been reviewing 3 or more pull requests per week, making one or more pull request per week, and triaging 3 or more issues a week.
 * The contributor is an exemplar of both Play's [code of conduct](/conduct) and [contributor guidelines](/contributing).
 * The contributor is well respected by other members of the Play community.
-* The contributor agrees to the rules set out by Typesafe below for integrators.
+* The contributor agrees to the rules set out by Lightbend below for integrators.
 
-Typesafe may also select integrators from its own staff.
+Lightbend may also select integrators from its own staff.
 
 If an integrator stops contributing regularly to Play, their write access may be removed, though their membership in the Play GitHub organisation will still be maintained.
 
@@ -89,7 +89,7 @@ All integrators should follow the processes outlined on this page, and should be
 * An integrator must never push directly to a repository in the GitHub organisation.  All contributions, no matter how small, must be made through pull requests.  The only exceptions to this are when backporting changes, and changes that arise from cutting a release.
 * Generally, pull requests should be made from integrators' personal forks, not from branches push to repositories in the playframework GitHub organisation.
 * An integrator must never merge their own pull requests.  All pull requests must be reviewed and merged by another integrator.
-* Documentation changes may be backported between releases as desired, however all other changes must by approved by Typesafe.
-* Integrators must enforce Typesafe's CLA requirements when merging pull requests.
+* Documentation changes may be backported between releases as desired, however all other changes must by approved by Lightbend.
+* Integrators must enforce Lightbend's CLA requirements when merging pull requests.
 * When closing issues or pull requests, remember that we are dealing with people.  Be kind and helpful, pointing people in the right direction.  For example, if someone raises an issue that is really a question, when closing the issue, direct them to the mailing list, providing a link to the mailing list, and if possible, a brief answer to the question.
 

--- a/public/markdown/contributing.md
+++ b/public/markdown/contributing.md
@@ -19,7 +19,7 @@ Before making a contribution, it is important to make sure that the change you w
 
 ### Procedure
 
-1. Make sure you have signed the [Typesafe CLA](http://www.typesafe.com/contribute/cla); if not, sign it online.
+1. Make sure you have signed the [Lightbend CLA](http://www.lightbend.com/contribute/cla); if not, sign it online.
 2. Ensure that your contribution meets the following guidelines:
     1. Live up to the current code standard:
         - Not violate [DRY](http://programmer.97things.oreilly.com/wiki/index.php/Don%27t_Repeat_Yourself).
@@ -41,7 +41,7 @@ Before making a contribution, it is important to make sure that the change you w
         * Features are forever, always think about whether a new feature really belongs to the core framework or if it should be implemented as a module
         * Code must conform to standard style guidelines and pass all tests (see [validatePullRequest](https://github.com/playframework/playframework/blob/master/framework/validatePullRequest))
     6. New files must:
-        * Have a Typesafe copyright header in the style of ``Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>``.
+        * Have a Lightbend copyright header in the style of ``Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>``.
         * Not use ``@author`` tags since it does not encourage [Collective Code Ownership](http://www.extremeprogramming.org/rules/collective.html).
 3. Ensure that your commits are squashed.  See [working with git](/documentation/latest/WorkingWithGit) for more information.
 4. Submit a pull request.
@@ -57,7 +57,7 @@ Generally, all bug fixes, improvements and new features will go to the master br
 * The change only affects the documentation
 * The change fixes a regression that was introduced in a previous stable release from that branch
 * The change fixes a bug that impacts significant number of members of the open source community with no simple work arounds available
-* Any other reason that Typesafe deems appropriate
+* Any other reason that Lightbend deems appropriate
 
 All backports and other commits to stable branches, in addition to satisfying the regular contributor guidelines, must also be binary and source compatible with previous releases on that branch.  The only exception to this is if a serious bug is impossible to fix without breaking the API, for example, a particular feature is not possible to use due to flaws in the API.
 


### PR DESCRIPTION
Changed links to point to lightbend.com and text to point to Lightbend where appropriate.

There are some pages I'm not too sure about, such as the historical Outreachy pages and the play 1.0 links which I have not changed.