### PR TITLE
Add example projects to Play downloads page

### DIFF
--- a/app/assets/css/pages/_download.styl
+++ b/app/assets/css/pages/_download.styl
@@ -17,7 +17,7 @@
 .download
     @extend .split-page
 
-    #content h1 
+    #content h1
         height: 80px
         line-height: 80px
         color: white
@@ -32,9 +32,9 @@
     .deprecated
         background: yellow
         padding: 30px
-    hr 
+    hr
         width: 70%
-        border: none 
+        border: none
         border-top: 1px solid #ddd
 
     .downloads
@@ -139,10 +139,9 @@
         margin: 10px 0 20px
 
 
-    .activator, .cli, .ui
+    .activator, .starter, .cli, .ui, .example-projects
         position: relative
         min-height: 300px
-        margin: 50px auto
         img
             position: absolute
             top: -10px
@@ -150,10 +149,22 @@
             margin: 14px 0 4px
         pre
             margin: 4px 0 14px
-    .activator
+    .activator, .starter
+        margin: 40px auto
         min-height: 10px
         width: 530px
         text-align: center
+    .cli, .ui
+        margin: 50px auto
+    .example-projects
+        margin: 0 150px 20px
+        table
+            tbody
+                border-top: 1px dotted #ccc
+                th
+                    padding: 5px 0
+                td
+                    border-bottom: 1px dotted #ccc
     .cli
         margin-left: 400px
         img
@@ -164,7 +175,7 @@
             right: -430px
 
     @media only screen and (max-width: 960px)
-        .activator, .cli, .ui
+        .activator, .cli, .ui, .sbt, .example-projects
             width: auto
             min-height: 10px
             margin: 10px
@@ -174,8 +185,7 @@
                 left: 0
                 right: 0
                 margin: 20px auto
-    .moto
-        color: green
+
 
 
 .get-started
@@ -223,5 +233,5 @@
     .bold
         font-size: 18px
         font-weight: bold
-        a 
+        a
             color: blue

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -147,7 +147,7 @@ $(function(){
         var versions = $("#alternatives .version");
 
         versions.each(function(i, el) {
-            var list = $("tr", el).slice(3).hide();
+            var list = $(".release", el).slice(3).hide();
             $(".show-all-versions", el).click(function() {
                 list.show();
                 $(this).hide();

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -25,7 +25,8 @@ class Application @Inject() (
   val messagesApi: MessagesApi,
   certificationDao: CertificationDao,
   @Named("activator-release-actor") activatorReleaseActor: ActorRef,
-  releases: PlayReleases
+  releases: PlayReleases,
+  exampleProjects: PlayExampleProjects
 )(implicit ec: ExecutionContext) extends Controller with Common with I18nSupport {
 
   private val VulnerableVersions = Set(
@@ -63,7 +64,7 @@ class Application @Inject() (
     val selectedPlatform = Platform(platform.orElse(request.headers.get("User-Agent")))
 
     latestActivator.map { activator =>
-      Ok(html.download(releases, activator, selectedPlatform))
+      Ok(html.download(releases, exampleProjects, activator, selectedPlatform))
     }
   }
 
@@ -75,15 +76,15 @@ class Application @Inject() (
   def changelog = markdownAction("public/markdown/changelog.md", { implicit request =>
     views.html.changelog(_)
   })
-  
+
   def conduct = markdownAction("public/markdown/code-of-conduct.md", { implicit request => markdown =>
     views.html.markdownPage("Code of conduct", markdown)
   })
-  
+
   def communityProcess = markdownAction("public/markdown/community-process.md", { implicit request => markdown =>
     views.html.markdownPage("Community process", markdown)
   })
-  
+
   def contributing = markdownAction("public/markdown/contributing.md", { implicit request => markdown =>
     views.html.markdownPage("Contributing", markdown)
   })

--- a/app/controllers/documentation/DocumentationController.scala
+++ b/app/controllers/documentation/DocumentationController.scala
@@ -75,7 +75,7 @@ class DocumentationController @Inject()(
       langs.find(_.satisfies(lang))
     }).orElse {
       candidateLangs.collect {
-        case Lang(l, c) if c.nonEmpty => Lang(l, "")
+        case lang: Lang if lang.country.nonEmpty => Lang(lang.language)
       }.collectFirst(Function.unlift { lang =>
         langs.find(_.satisfies(lang))
       })

--- a/app/controllers/documentation/Router.scala
+++ b/app/controllers/documentation/Router.scala
@@ -71,16 +71,9 @@ class Router @Inject() (
   }
 }
 
-object ReverseRouter {
-  private def instance: ReverseRouter = play.api.Play.current.injector.instanceOf[ReverseRouter]
-  def index(lang: Option[Lang]) = instance.index(lang)
-  def home(lang: Option[Lang], version: String) = instance.home(lang, version)
-  def page(lang: Option[Lang], version: String, page: String = "Home") = instance.page(lang, version, page)
-  def api(version: String, path: String) = instance.api(version, path)
-  def latest(lang: Option[Lang], page: String = "Home") = instance.latest(lang, page)
-  def cheatsheet(lang: Option[Lang], version: String, category: String) = instance.cheatsheet(lang, version, category)
-  def switch(lang: Option[Lang], version: String, page: String) = instance.switch(lang, version, page)
-}
+object ReverseRouter extends ReverseRouter(new Provider[Router] {
+  def get = play.api.Play.current.injector.instanceOf[Router]
+})
 
 @Singleton
 class ReverseRouter @Inject() (routerProvider: Provider[Router]) {

--- a/app/models/PlayExampleProjects.scala
+++ b/app/models/PlayExampleProjects.scala
@@ -1,0 +1,43 @@
+package models
+
+import com.google.inject.{Singleton, Provides, AbstractModule}
+import org.apache.commons.io.IOUtils
+import play.api.Environment
+import play.api.libs.json.Json
+
+case class ExampleProject(
+  name: String,
+  playVersion: String,
+  githubUrl: String,
+  downloadUrl: String
+)
+
+object ExampleProject {
+  implicit val format = Json.format[ExampleProject]
+}
+
+case class PlayExampleProjects(projects: Seq[ExampleProject] = Seq.empty) {
+  lazy val byVersion: Seq[(String, Seq[ExampleProject])] = {
+    projects.groupBy(_.playVersion).toSeq.sortBy(_._1).reverse
+  }
+}
+
+object PlayExampleProjects {
+  implicit val format = Json.format[PlayExampleProjects]
+}
+
+class ExamplesModule extends AbstractModule {
+  override def configure() = ()
+
+  // TODO something nicer here
+  @Provides @Singleton def examples(environment: Environment): PlayExampleProjects = {
+    // TODO: this will eventually be replaced by an API from the example code service
+    environment.resourceAsStream("playExamples.json").flatMap { is =>
+      try {
+        Json.fromJson[PlayExampleProjects](Json.parse(IOUtils.toByteArray(is))).asOpt
+      } finally {
+        is.close()
+      }
+    }.getOrElse(PlayExampleProjects())
+  }
+}

--- a/app/views/download.scala.html
+++ b/app/views/download.scala.html
@@ -1,4 +1,5 @@
-@(releases: PlayReleases, activator: ActivatorRelease, platform: Platform.Platform, title: String = "Downloads")(implicit requestHeader : RequestHeader)
+@(releases: PlayReleases, examples: PlayExampleProjects, activator: ActivatorRelease, platform: Platform.Platform,
+        title: String = "Downloads")(implicit requestHeader : RequestHeader)
 
 @renderRelease(linkClass: String, release: PlayRelease) = {
     @if(release.secureUrl) {
@@ -14,7 +15,6 @@
     } else {
         <td width="250">
             Play @release.version
-            <span class="small">(<a href="@activator.miniSecureUrl" class="downloadActivatorLink" data-version="old">activator</a>)</span>
         </td>
         <td width="200">
             @release.date
@@ -60,6 +60,37 @@
             </div>
         </div>
 
+        <article class="starter">
+            <h2>Play starter projects</h2>
+            <h3>One download to get started</h3>
+        </article>
+
+        <hr />
+
+        <article id="examples" class="example-projects">
+            <p>
+                These projects all include an <a href="http://www.scala-sbt.org/index.html">SBT</a> launcher that can
+                be run with <code>./sbt</code>. Edit <code>build.sbt</code> to change your project name and settings,
+                and use <code>./sbt run</code> to run your project.
+            </p>
+
+            <table>
+            @examples.byVersion.map { case (version, projects) =>
+                <tbody>
+                    <tr><th><h4>Play @version</h4></th></tr>
+                    @projects.map { project =>
+                        <tr>
+                            <td><strong><a href="@project.downloadUrl" target="_blank">@project.name</a></strong></td>
+                            <td><a href="@project.downloadUrl" target="_blank">Download (zip)</a></td>
+                            <td><a href="@project.githubUrl" target="_blank">View on GitHub</a></td>
+                        </tr>
+                    }
+                </tbody>
+            }
+            </table>
+
+        </article>
+        <hr/>
         <article class="activator">
             <h2>Play with Activator</h2>
             <h3>Install and run Play projects with Activator</h3>
@@ -67,7 +98,7 @@
         <hr/>
         <article class="cli">
             <img src="@routes.Assets.versioned("images/download/cli.png")">
-            <h2>Play from the command line</h2>
+            <h3>Activator from the command line</h3>
             <p><a href="@controllers.documentation.ReverseRouter.latest(None, "Installing")">Add activator your PATH</a> to have the command available in your cli.</p>
             <p>Create a new project from the command line:</p>
             <pre>activator new</pre>
@@ -79,25 +110,25 @@
         <hr/>
         <article class="ui">
             <img src="@routes.Assets.versioned("images/download/ui.png")">
-            <h2>Activator’s ui and tutorials</h2>
-            <h3 class="moto">Learn. Compile. Test. Run.</h3>
-            <p>Activator comes with a ui for learning Play. Launch the ui by double clicking the activator executable or using the following command in your terminal:</p>
+            <h3>Activator’s UI and tutorials</h3>
+            <p>Activator comes with a user interface for learning Play. Launch the ui by double clicking the activator
+                executable or using the following command in your terminal:</p>
             <pre>activator ui</pre>
             <p>A webpage will open in your browser, then follow the instructions to choose and open a tutorial.</p>
             <p>Read more about <a href="@controllers.documentation.ReverseRouter.latest(None, "Tutorials")">Activator Tutorials</a> for Play.</p>
-        </article>
-        <hr/>
-        <article class="activator">
-            <h2>More about Activator</h2>
-            <p>Lightbend Activator gets you started with Play and the <a href="//lightbend.com/products/lightbend-reactive-platform" target="_blank">Lightbend Reactive Platform</a>. It is a hub for developers that want to build reactive applications, providing both a command line and an in browser environment for creating new applications.</p>
-            <p>Getting started is a snap, please refer to the following instructions or the complete <a href="//lightbend.com/activator/download" target="_blank">Getting Started</a> page, including an introduction video.</p>
         </article>
         <hr/>
         <article id="alternatives">
             <h2>Alternative downloads</h2>
             <section>
             <p>
-                The Traditional Play Zip provides a <code>play</code> command to create new applications, run tests, and run the application.  Check out the Play docs for <a href="@controllers.documentation.ReverseRouter.latest(None, "Installing")">Installation instructions</a>.
+                The Traditional Play Zip provides a <code>play</code> command to create new applications, run tests,
+                and run the application. After 2.3.0 the <code>play</code> command is no longer used. Projects can be
+                created from an existing example project or through Activator, as described above.
+            </p>
+            <p>
+                Check out the Play docs for
+                <a href="@controllers.documentation.ReverseRouter.latest(None, "Installing")">installation instructions</a>.
             </p>
 
             @if(releases.development.nonEmpty) {
@@ -117,30 +148,31 @@
             }
 
             <hr/>
+
             <h3 id="older-versions">Previous releases</h3>
 
             <p class="changelogLink"><a href="@routes.Application.changelog()">Changelog</a></p>
 
+            <table class="releases">
             @releases.previous.groupBy(_.version.slice(0,3)).toSeq.sortBy(_._1).reverse.map { group =>
-                <div class="version">
-                    <h3 colspan="3">@group._1</h3>
-                    <table>
+                <tbody class="version">
+                    <tr><th colspan="3"><h4>@group._1</h4></th></tr>
                     @group._2.map { release =>
-                        <tr>
+                        <tr class="release">
                             @renderRelease("downloadPreviousLink", release)
                         </tr>
                     }
-                    </table>
-                    <span class="show-all-versions">Show all versions</span>
-                </div>
+                    <tr><td class="show-all-versions">Show all versions</td></tr>
+                </tbody>
             }
+            </table>
         </section>
         <section>
             <h3 id="as-dependency">Play as a dependency</h3>
             <p>You can find instructions on how to create a Play application with sbt in the last section of the <a href="@controllers.documentation.ReverseRouter.latest(None, "NewApplication")">creating a new application</a> page.</p>
             <hr/>
             <h3 id="from-source">Build from source</h3>
-            <p>The source code is hosted on Github, you can follow the instructions on the <a href="@controllers.documentation.ReverseRouter.latest(None, "BuildingFromSource")">Build from the sources</a> page.</p>
+            <p>The source code is hosted on Github. You can follow the instructions on the <a href="@controllers.documentation.ReverseRouter.latest(None, "BuildingFromSource")">Building from source</a> page.</p>
         </section>
 
         </article>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -5,6 +5,7 @@ play {
   modules {
     enabled += services.github.GitHubModule
     enabled += services.releases.ReleasesModule
+    enabled += models.ExamplesModule
     enabled += actors.ActorsModule
   }
 

--- a/conf/playExamples.json
+++ b/conf/playExamples.json
@@ -1,0 +1,58 @@
+{
+  "projects": [
+    {
+      "name": "Play Scala Seed",
+      "playVersion": "2.5.x",
+      "githubUrl": "https://github.com/playframework/play-scala",
+      "downloadUrl": "https://example.lightbend.com/v1/download/play-2.5.x-scala"
+    },
+    {
+      "name": "Play Java Seed",
+      "playVersion": "2.5.x",
+      "githubUrl": "https://github.com/playframework/play-java",
+      "downloadUrl": "https://example.lightbend.com/v1/download/play-2.5.x-java"
+    },
+    {
+      "name": "Play Scala with Slick",
+      "playVersion": "2.5.x",
+      "githubUrl": "https://github.com/playframework/play-scala-intro",
+      "downloadUrl": "https://example.lightbend.com/v1/download/play-2.5.x-scala-intro"
+    },
+    {
+      "name": "Play Java with JPA",
+      "playVersion": "2.5.x",
+      "githubUrl": "https://github.com/playframework/play-java-intro",
+      "downloadUrl": "https://example.lightbend.com/v1/download/play-2.5.x-java-intro"
+    },
+    {
+      "name": "Play Scala Seed",
+      "playVersion": "2.4.x",
+      "githubUrl": "https://github.com/playframework/play-scala",
+      "downloadUrl": "https://example.lightbend.com/v1/download/play-2.4.x-scala"
+    },
+    {
+      "name": "Play Java Seed",
+      "playVersion": "2.4.x",
+      "githubUrl": "https://github.com/playframework/play-java",
+      "downloadUrl": "https://example.lightbend.com/v1/download/play-2.4.x-java"
+    },
+    {
+      "name": "Play Scala with Slick",
+      "playVersion": "2.4.x",
+      "githubUrl": "https://github.com/playframework/play-scala-intro",
+      "downloadUrl": "https://example.lightbend.com/v1/download/play-2.4.x-scala-intro"
+    },
+    {
+      "name": "Play Java with JPA",
+      "playVersion": "2.4.x",
+      "githubUrl": "https://github.com/playframework/play-java-intro",
+      "downloadUrl": "https://example.lightbend.com/v1/download/play-2.4.x-java-intro"
+    },
+    {
+      "name": "Play Rest API",
+      "playVersion": "2.5.x",
+      "githubUrl": "https://github.com/playframework/play-rest-api",
+      "downloadUrl": "https://example.lightbend.com/v1/download/play-rest-api"
+    }
+  ]
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.0")
-addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.9")
+addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.0")
-addSbtPlugin("com.typesafe.sbt" % "sbt-stylus" % "1.0.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-stylus" % "1.0.3")


### PR DESCRIPTION
Adds an example projects section to the Play download page at the top of the download page:

![screenshot](http://i.imgur.com/4xB6ERs.png)

/cc @corruptmemory

Once we've updated the API to allow us to fetch the sample project names, we should be able to use that for metadata instead of the hard-coded JSON.