### PR TITLE
Make sure home and download pages look good on smaller screens

### DIFF
--- a/app/assets/css/modules/_page.styl
+++ b/app/assets/css/modules/_page.styl
@@ -39,7 +39,7 @@
     h1:hover > a, h2:hover > a, h3:hover > a, h4:hover > a, h5:hover > a
         visibility: visible
         color: inherit
-        text-decoration: none        
+        text-decoration: none
 
 article, aside
     @extend .typo
@@ -106,8 +106,6 @@ article, aside
     #content
         padding: 0
         padding-top 10px
-        // background: image("support/line.png") left top repeat-x
-        // retina("support/line.png", 100% 80px)
         background-size: 100% 80px
 
         section
@@ -132,8 +130,6 @@ article, aside
                 text: big
 
         @media only screen and (max-width: 960px)
-            background: image("support/line.png") left top repeat-x
-            background-size: 100% 80px
             section
                 width: 100%
                 float: none

--- a/app/assets/css/pages/_home.styl
+++ b/app/assets/css/pages/_home.styl
@@ -57,64 +57,20 @@
             text: title bold
             font-size: 1.2em
 
-#start
-    float: left
-    width: 260px
+#actions
+    text-align: center
+    &>div
+        display: inline-block
+        width: 260px
+        margin: 20px 10px
     h2
         text-align: center
-        margin: 30px 0 10px
-        color: grey-dark
-        text: title big uppercase
-
-    .download
-        height: 75px
-        button: green
-
-    .getting-started
-        position: relative
-        clear: after
-        a
-            float: left
-            width: 50%
-            button: green
-            border-left: 1px solid green + #111
-            border-right: 1px solid green - #111
-            &:first-child
-                border-radius: 5px 0 0 5px
-                border-left: none
-            &:last-child
-                border-radius: 0 5px 5px 0
-                border-right: none
-        &:before
-            content: "&"
-            absolute: top 50% left 50%
-            circle: 20px
-            margin: -12px 0 0 -10px
-            background: green - #444
-            box-shadow: inset 0 1px 5px rgba(#000, .3), 0 1px 0 rgba(#fff, .5)
-            color: white
-
-    p
         margin: 10px 0
-        text: center
-        a
-            color: grey-text
-            text: underline
-            &:hover
-                color: grey-text - #222
-                text: no-underline
-
-#docs
-    float: left
-    margin-left: 50px
-    width: 260px
-    h2
-        text-align: center
-        margin: 30px 0 10px
         color: grey-dark
+        padding-top: 10px
         text: title big uppercase
 
-    .dochome
+    .button
         height: 75px
         button: green
 
@@ -127,31 +83,6 @@
             &:hover
                 color: grey-text - #222
                 text: no-underline
-
-#tutorials
-    float: left
-    margin-left: 50px
-    width: 260px
-    h2
-        text-align: center
-        margin: 30px 0 10px
-        color: grey-dark
-        text: title big uppercase
-
-    .tutpage
-        height: 75px
-        button: green
-
-    p
-        margin: 10px 0
-        text: center
-        a
-            color: grey-text
-            text: underline
-            &:hover
-                color: grey-text - #222
-                text: no-underline
-
 
 #workflow
     absolute: top 0px left 0
@@ -314,14 +245,15 @@
                 height: auto
                 margin: 0
                 padding-left: 0
+                text-align: center
                 background: none
 
         #content
             margin: 0
 
-        #video, #start
-            float: none
-            margin: 20px auto
+        #actions>div
+            margin-top: 0
+            margin-bottom: 0
         article.feature
             padding: 0 !important
             height: auto !important
@@ -334,5 +266,5 @@
             width: auto
 
 @media only screen and (max-width: 700px)
-    #video, #start
+    #actions
         display: none

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -11,30 +11,32 @@
         </div>
     </header>
     <section id="content">
-        <div id="start">
-            <h2>Get the latest package</h2>
-                <a href="@routes.Application.download()" class="download">Download <br> @releases.latest.version@for(name <- releases.latest.name){ "@name"}</a>
-            <p>
-                or <a href="@routes.Application.download()#older-versions">browse all versions</a>
-            </p>
-        </div>
+        <div id="actions">
+            <div id="start">
+                <h2>Get the latest package</h2>
+                    <a href="@routes.Application.download()" class="button">Download <br> @releases.latest.version@for(name <- releases.latest.name){ "@name"}</a>
+                <p>
+                    or <a href="@routes.Application.download()#older-versions">browse all versions</a>
+                </p>
+            </div>
 
-        <div id="docs">
-            <h2>Read the Docs</h2>
+            <div id="docs">
+                <h2>Read the Docs</h2>
 
-            <a href="@controllers.documentation.ReverseRouter.index(None)" class="dochome">Documentation <br> @releases.latest.version@for(name <- releases.latest.name){ "@name"}</a>
-            <p>
-              or go to <a href="@controllers.documentation.ReverseRouter.latest(None, "JavaHome")">Java docs</a> or <a href="@controllers.documentation.ReverseRouter.latest(None, "ScalaHome")">Scala docs</a>
-            </p>
+                <a href="@controllers.documentation.ReverseRouter.index(None)" class="button">Documentation <br> @releases.latest.version@for(name <- releases.latest.name){ "@name"}</a>
+                <p>
+                  or go to <a href="@controllers.documentation.ReverseRouter.latest(None, "JavaHome")">Java docs</a> or <a href="@controllers.documentation.ReverseRouter.latest(None, "ScalaHome")">Scala docs</a>
+                </p>
 
-        </div>
+            </div>
 
-        <div id="tutorials">
-            <h2>Play with Tutorials</h2>
-            <a href='@controllers.documentation.ReverseRouter.latest(None, "Tutorials")' class="tutpage">Tutorials <br> @releases.latest.version@for(name <- releases.latest.name){ "@name"}</a>
-            <p>
-                or <a href="/documentation/latest/Tutorials#Third-Party-Tutorials-and-Templates">blog posts</a> or <a href="@controllers.documentation.ReverseRouter.latest(None, "ModuleDirectory")">modules</a>
-            </p>
+            <div id="tutorials">
+                <h2>Play with Tutorials</h2>
+                <a href='@controllers.documentation.ReverseRouter.latest(None, "Tutorials")' class="button">Tutorials<br> @releases.latest.version@for(name <- releases.latest.name){ "@name"}</a>
+                <p>
+                    or <a href="/documentation/latest/Tutorials#Third-Party-Tutorials-and-Templates">blog posts</a> or <a href="@controllers.documentation.ReverseRouter.latest(None, "ModuleDirectory")">modules</a>
+                </p>
+            </div>
         </div>
 
         <article class="hat">


### PR DESCRIPTION
This removes the annoying black bar when viewing the download page on a narrow screen, and also makes sure the buttons on the home page are centered and show up. These buttons are hidden for screens below 700px since links to the same content appear elsewhere on the page.