### PR TITLE
Allow downloading of seeds directly from site

### DIFF
--- a/app/assets/css/pages/_download.styl
+++ b/app/assets/css/pages/_download.styl
@@ -176,6 +176,16 @@
                     padding: 5px 0
                 td
                     border-bottom: 1px dotted #ccc
+        .seed-project
+            display: block
+            margin: 10px 0 10px
+        .template-form
+            display: block
+            label, input
+                font-size: 12px
+            .template-param
+                display: inline-block
+                padding: 10px 15px 10px 0
     .example-projects
         margin: 0 150px 20px
         table

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -167,19 +167,20 @@ class Application @Inject() (
 
     val sections = byVersion.map { case (v, p) =>
       val StarterKeyword = "starter" // this MUST be in the project keywords for this to work
-      val starters = p.filter(_.keywords.contains(StarterKeyword))
+      val SeedKeyword = "seed"
+      val starters = p.filter(e => e.keywords.contains(StarterKeyword) && !e.hasParams)
         .groupBy(byLanguage)
         .mapValues(_.sortBy(_.displayName))
 
-      val examples = p.filter(p => !p.keywords.contains(StarterKeyword) && !p.hasParams)
+      val examples = p.filter(e => !e.keywords.contains(StarterKeyword) && !e.hasParams)
         .groupBy(byLanguage)
         .mapValues(_.sortBy(_.displayName))
 
-      val templates = p.filter(_.hasParams)
+      val seeds = p.filter(e => e.hasParams && e.keywords.contains(SeedKeyword))
         .groupBy(byLanguage)
         .mapValues(_.sortBy(_.displayName))
 
-      v -> PlayExampleSection(starters, templates, examples)
+      v -> PlayExampleSection(starters, seeds, examples)
     }
     PlayExamples(sections)
   }
@@ -188,5 +189,5 @@ class Application @Inject() (
 case class PlayExamples(sections: Seq[(String, PlayExampleSection)])
 
 case class PlayExampleSection(starters: Map[String, Seq[ExampleProject]],
-                              templates: Map[String, Seq[ExampleProject]],
+                              seeds: Map[String, Seq[ExampleProject]],
                               examples: Map[String, Seq[ExampleProject]])

--- a/app/models/PlayExampleProjects.scala
+++ b/app/models/PlayExampleProjects.scala
@@ -13,9 +13,11 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 case class TemplateParameter(
+  `type`: String,
   query: String,
   displayName: String,
   required: Boolean,
+  defaultValue: Option[String],
   pattern: Option[String],
   format: Option[String]
 )

--- a/app/views/download.scala.html
+++ b/app/views/download.scala.html
@@ -62,7 +62,7 @@
 
     <hr />
 
-    @seedDownload(/* TODO: add rendering for template parameters */)
+    @seedDownload(examples)
 
     <hr />
 

--- a/app/views/seedDownload.scala.html
+++ b/app/views/seedDownload.scala.html
@@ -1,4 +1,4 @@
-@()
+@(downloads: PlayExamples)
 
 <article class="starter">
   <h2 id="seeds">Play Seed Templates</h2>
@@ -33,9 +33,28 @@
     from sbt to create the scaffold controller, template and tests needed to process a form. You can also create your own giter8 seeds and scaffolds based off this one by forking from the <a href="https://github.com/playframework/play-java-seed.g8">https://github.com/playframework/play-java-seed.g8</a> or <a href="https://github.com/playframework/play-scala-seed.g8">https://github.com/playframework/play-scala-seed.g8</a> github projects.
   </p>
 
-  <h4>Play Java Seed</h4>
-  <pre><code>sbt new playframework/play-java-seed.g8</code></pre>
+  @downloads.sections.headOption.toIterable.flatMap(_._2.seeds.values.flatten.filter(_.gitHubRepo.endsWith(".g8"))).map { project: ExampleProject =>
+    <div class="seed-project">
+      <h4>@project.displayName</h4>
+      <pre><code>sbt new @project.gitHubRepo</code></pre>
 
-  <h4>Play Scala Seed</h4>
-  <pre><code>sbt new playframework/play-scala-seed.g8</code></pre>
+      <h5>Download directly:</h5>
+      <form class="template-form" target="_blank" method="get" action="@project.downloadUrl">
+        @project.params.map { param =>
+          <label class="template-param">@param.displayName:
+            <input
+                type="@{param.`type`}"
+                name="@param.query"
+                @param.defaultValue.map { v => value="@v" }
+                @param.pattern.map {p => pattern="@p" }
+                @if(param.required) { required }
+            >
+          </label>
+        }
+        <label class="template-param">
+          <input type="submit" value="Download Project">
+        </label>
+      </form>
+    </div>
+  }
 </article>


### PR DESCRIPTION
The HTML for the seed projects is now generated from the example code service. It shows both the `sbt new` command and a form to download.

![](https://i.imgur.com/lZBe7Qj.png])