### PR TITLE
Update link to the Guardian using current domain and scheme

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -146,7 +146,7 @@
             <h2>They already use Play Framework</h2>
             <a class="linkedin" href="//linkedin.com">Linkedin</a>
             <a class="klout" href="//klout.com">Klout</a>
-            <a class="guardian" href="http://m.guardian.co.uk/">The Guardian</a>
+            <a class="guardian" href="https://www.theguardian.com/">The Guardian</a>
             <a class="gilt" href="http://www.gilt.com">Gilt</a>
         </div>
 


### PR DESCRIPTION
We've changed domain...

https://www.theguardian.com/info/developer-blog/2014/feb/18/how-the-guardian-successfully-moved-domain

...and shifted to HTTPS-only!

https://www.theguardian.com/info/developer-blog/2016/nov/29/the-guardian-has-moved-to-https