### PR TITLE
Fix outreachy site

### DIFF
--- a/app/views/outreachy/round15.scala.html
+++ b/app/views/outreachy/round15.scala.html
@@ -14,9 +14,9 @@
 
             <p>
                 Lightbend and Play Framework are proud to be participating in
-                <a href="https://gnome.org/outreachy/">Outreachy</a>, a program to help groups that are underrepresented
+                <a href="https://www.outreachy.org/">Outreachy</a>, a program to help groups that are underrepresented
                 in free and open source software get involved. For detailed information about Outreachy, including how
-                to apply, see the <a href="https://wiki.gnome.org/Outreachy">main program page</a>.
+                to apply, see the <a href="https://www.outreachy.org/apply/">main application page</a>.
             </p>
 
             <p>


### PR DESCRIPTION
We were linking to the old urls for outreachy.