### PR TITLE
Changed security email address to playframework.com

### DIFF
--- a/app/views/vulnerabilities.scala.html
+++ b/app/views/vulnerabilities.scala.html
@@ -21,7 +21,7 @@
                 We strongly encourage people to report such problems to our private security mailing list first, before disclosing them in a public forum.
             </p>
             <p>
-                All security bugs in Play should be reported by email to <a href="mailto:security@@playframework.org">security@@playframework.org</a>. This list is delivered to a subset of the core team who handle security issues.
+                All security bugs in Play should be reported by email to <a href="mailto:security@@playframework.com">security@@playframework.com</a>. This list is delivered to a subset of the core team who handle security issues.
             </p>
 
             <h2>Play 2.6.x<h2>


### PR DESCRIPTION
security@playframework.org still works, but it should be playframework.com.