### PR TITLE
The url to access the example wasn't displaying because the <ol> list…

### DIFF
--- a/app/views/gettingStarted.scala.html
+++ b/app/views/gettingStarted.scala.html
@@ -54,9 +54,10 @@
                         <li>Unzip the project in a convenient location.</li>
                         <li>In a command window, change to the top-level project directory.</li>
                         <li>Enter <code>sbt run</code>.</li>
-                        <li>After the message <code>Server started, ...</code> displays, enter the following URL in a browser: <http://localhost:9000>
-                        <p>The tutorial welcome page displays.</p></li>
-                        <ol>
+                        <li>After the message <code>Server started, ...</code> displays, enter the following URL in a browser: <code>http://localhost:9000</code></li>
+                        
+                        </ol>
+                       <p>The tutorial welcome page displays.</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
… wasn't terminated properly.

