### PR TITLE
Remove Google+

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -62,7 +62,6 @@
                 <nav id="social">
                     <a href="//discuss.playframework.com"><span>Discuss Play Forum</span></a>
                     <a href="//twitter.com/playframework"><span>Twitter</span></a>
-                    <a href="//plus.google.com/106233335814246022600"><span>Google+</span></a>
                     <a href="//www.facebook.com/pages/Play-Framework/50884087887"><span>Facebook</span></a>
                     <a href="//github.com/playframework/playframework"><span>GitHub</span></a>
                     <a href="//stackoverflow.com/questions/tagged/playframework"><span>Stackoverflow</span></a>
@@ -162,7 +161,6 @@
                     <h3>Social networks</h3>
                     <ul>
                         <li><a href="//twitter.com/playframework"><span>Twitter</span></a></li>
-                        <li><a href="//plus.google.com/106233335814246022600"><span>Google+</span></a></li>
                         <li><a href="//www.facebook.com/pages/Play-Framework/50884087887"><span>Facebook</span></a></li>
                     </ul>
                 </div>


### PR DESCRIPTION
Google+ is being shutdown:

https://support.google.com/plus/answer/9195133?hl=en-GB&authuser=0

This removes all links to it.