### PR TITLE
Fix broken styles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tmp
 .history
 dist
 /.idea
+/.ensime
 /*.iml
 /out
 /.idea_modules

--- a/app/assets/css/pages/_documentation.styl
+++ b/app/assets/css/pages/_documentation.styl
@@ -29,6 +29,7 @@ hr.clear
             padding: 0
             background: white
             border-right: 1px solid sand
+            overflow-wrap: break-word;
 
             #search
                 input:focus
@@ -113,6 +114,9 @@ hr.clear
             table
                 border: 1px solid #ddd
                 border-collapse: collapse
+                display: block;
+                border: none;
+                overflow: scroll;
 
                 th
                     font-weight: bold


### PR DESCRIPTION
When opening via phone or tablets, some contents overflowed.
But it looks bad, and should wrap or be scrollable.
Related to https://github.com/playframework/playframework.com/issues/180.

I think [this link](https://www.playframework.com/documentation/2.6.x/Migration26) is most ugly, and took some screenshots for example.

## Before

<img width="488" alt="スクリーンショット 2019-03-10 23 56 42" src="https://user-images.githubusercontent.com/7848879/54086816-472d1800-4390-11e9-8a7d-6f697ad3a932.png">

## After

<img width="474" alt="スクリーンショット 2019-03-10 23 57 28" src="https://user-images.githubusercontent.com/7848879/54086815-472d1800-4390-11e9-88e4-98526355cc26.png">
