### PR TITLE
Show translated documentation only when the latest version is translated

### DIFF
--- a/app/controllers/documentation/DocumentationController.scala
+++ b/app/controllers/documentation/DocumentationController.scala
@@ -238,15 +238,15 @@ class DocumentationController @Inject()(
         // requested the default lang
         case Some(l) if l == summary.defaultLang => None -> summary.defaultLatest
         // requested a specific translation
-        case Some(l) if summary.translations.contains(l) => lang -> summary.translations(l)
+        case Some(l) if hasLatestDocumentation(summary, l) => lang -> summary.translations(l)
         // requested an unknown translation
         case Some(missing) => None -> None
         case None          =>
           // This is the only place where we do accept header based language detection, on the documentation home page
           val autoLang = preferredLang(summary.allLangs)
           autoLang match {
-            case Some(l) if summary.translations.contains(l) => autoLang -> summary.translations(l)
-            case _                                           => None     -> summary.defaultLatest
+            case Some(l) if hasLatestDocumentation(summary, l) => autoLang -> summary.translations(l)
+            case _                                             => None     -> summary.defaultLatest
           }
       }
       version
@@ -257,6 +257,9 @@ class DocumentationController @Inject()(
         .getOrElse(pageNotFound(summary.translationContext, path, Nil))
     }
   }
+
+  private def hasLatestDocumentation(summary: DocumentationSummary, lang: Lang): Boolean =
+    summary.translations.contains(lang) && summary.translations(lang) == summary.defaultLatest
 
   def sitemap = DocsAction { actor => implicit req =>
     (actor ? GetSitemap).mapTo[DocumentationSitemap].map { docSitemap =>


### PR DESCRIPTION
Related to
 - https://github.com/playframework/playframework/issues/8609
 - https://github.com/playframework/playframework.com/issues/252

I changed the behavior of "showing old Japanese documents when accessing the latest document" and changed to "show English documents if there is no corresponding Japanese document for the latest version".

## Background

There used to be a project to translate documents into Japanese, but unfortunately that project has already become inactive. The latest version of the Japanese document is 2.4.

playframework.com gives preference to language over version when accessing the latest documentation. As a result, Japanese users are always shown outdated documents, and I have seen people who are in trouble by referring to information that is already incorrect. I have told many people, "Please do not look at Japanese documents."

And even worse, this is a problem not only in Japanese but also in French etc.