### PR TITLE
fix unreadable texts for mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ dist
 /RUNNING_PID
 .DS_Store
 **/.DS_Store
-data
+data/*
+!*.keep
 conf/generated.keystore

--- a/app/assets/css/modules/_typography.styl
+++ b/app/assets/css/modules/_typography.styl
@@ -178,8 +178,8 @@
         background: #f5f5f5
 
     code 
-        height: 4px
-        padding: .2em .4em
+        line-height: 1em
+        padding: 0em .4em
         background: #f2f2f2
         color: #666
         border-radius: 3px
@@ -194,6 +194,9 @@
         border: 0
         border-radius: 0
         font-size: 14px
+
+    li code
+        line-height: 1.2em
 
     blockquote,
     blockquote p,


### PR DESCRIPTION
some text for `<code>` is overlaid and un-readable for mobile.
Fixed it :smile: 

## Before
![Screenshot from 2019-04-27 16-26-05](https://user-images.githubusercontent.com/7848879/56846516-29e5e600-690b-11e9-80d2-ecba951f704a.png)

## After
![Screenshot from 2019-04-27 16-35-50](https://user-images.githubusercontent.com/7848879/56846518-32d6b780-690b-11e9-830c-78afedaa4b71.png)
