### PR TITLE
Redirect JavaEbean to GitHub

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -138,6 +138,7 @@ documentation {
     { from = "ScalaTest",                   to = "ScalaTestingYourApplication"                                       },
     { from = "ScalaTodoList",               to = "HelloWorldTutorial"                                                },
     { from = "WSQuickStart",                to = "https://lightbend.github.io/ssl-config/WSQuickStart.html"          },
+    { from = "JavaEbean",                   to = "https://github.com/playframework/play-ebean/"                      },
   ]
 }
 


### PR DESCRIPTION
After https://github.com/playframework/omnidoc/pull/61, going to https://www.playframework.com/documentation/2.7.x/JavaEbean causes a `404`.

With this new redirect, both 

1. https://www.playframework.com/documentation/2.7.x/JavaEbean
2. https://www.playframework.com/documentation/2.8.0-M1/JavaEbean

will return a redirect (see #325) while any `GET` to a version that has the `JavaEbean` will be able to render that page.

We still need to see if keeping `JavaEbean` on the ToC https://www.playframework.com/documentation/2.7.x/JavaHome is what we want, though. But that discussion will/should be addressed on a separate PR.

Related to https://github.com/playframework/playframework.com/issues/325