### PR TITLE
ccpa cookie banner upgrade

### DIFF
--- a/app/assets/css/modules/_oneTrust.styl
+++ b/app/assets/css/modules/_oneTrust.styl
@@ -61,3 +61,47 @@ body .optanon-alert-box-wrapper .optanon-alert-box-bottom-padding
                 &:hover
                     background: green-dark
                     color: white
+
+//ontrust ccpa upgrades
+body
+    #onetrust-pc-sdk .ot-switch
+        width: 45px !important
+        padding: 0 !important
+    #onetrust-pc-sdk .ot-switch-nob:before 
+        transform: translateX(2px) 
+    .onetrust-pc-dark-filter
+        background: rgba(0,0,0,.75)
+    #onetrust-button-group
+        display: flex !important
+        flex-direction: row-reverse !important
+        justify-content: flex-end !important
+        text-align: left !important
+    #onetrust-accept-btn-handler
+        opacity: 1 !important
+        transition: anime
+        outline: none !important
+        &:hover
+            background-color: green !important
+            border-color: green !important
+            transition: anime
+    #onetrust-pc-sdk #close-pc-btn-handler.ot-close-icon
+        outline: none !important
+    .ot-pc-footer-logo
+        display: none
+    #ot-sdk-cookie-policy,
+    #cookie-policy-description,
+    .ot-sdk-cookie-policy-group-desc
+        font-size: 1rem !important
+        line-height: 1.5 !important
+        margin-bottom: 1.0625rem !important
+        & p
+            font-size: 1rem !important
+            line-height: 1.5 !important
+            margin-bottom: 1.0625rem !important
+    #onetrust-pc-sdk .ot-cat-grp .ot-always-active
+        color: #6cc04a
+    #onetrust-pc-sdk .ot-tgl input:checked+.ot-switch .ot-switch-nob
+        border-color: #6cc04a
+        background-color: #d4e8cb
+        &:before
+            background-color: #6cc04a

--- a/app/views/cookie.scala.html
+++ b/app/views/cookie.scala.html
@@ -13,7 +13,7 @@
         <article>
             <h1>Your Privacy</h1>
             <p>When you visit any web site, it may store or retrieve information on your browser, mostly in the form of cookies. This information might be about you, your preferences or your device and is mostly used to make the site work as you expect it to. The information does not usually directly identify you, but it can give you a more personalised web experience.</p>
-            <p>Because we respect your right to privacy, you <a class="optanon-toggle-display">can choose</a> not to allow some types of cookies. Below is a list of the cookies that get set on the playframework.com domain. Blocking some types of cookies may impact your experience of the site and the services we are able to offer.</p>
+            <p>Because we respect your right to privacy, you <a onclick="OneTrust.ToggleInfoDisplay();">can choose</a> not to allow some types of cookies. Below is a list of the cookies that get set on the playframework.com domain. Blocking some types of cookies may impact your experience of the site and the services we are able to offer.</p>
             <p><a class="optanon-toggle-display button">COOKIE SETTINGS</a></p>
             <br><hr><br>
             <h1>Cookie Listing</h1>

--- a/app/views/cookie.scala.html
+++ b/app/views/cookie.scala.html
@@ -18,7 +18,7 @@
             <br><hr><br>
             <h1>Cookie Listing</h1>
             <!-- OneTrust Cookies Policy start -->
-            <div id="optanon-cookie-policy"></div>
+            <div id="ot-sdk-cookie-policy"></div>
             <!-- OneTrust Cookies Policy end -->
 
         </article>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -177,7 +177,7 @@
             </div>
             <div class="lb-legal">
                 <p>
-                    &copy; Lightbend 2018 |
+                    &copy; Lightbend 2021 |
                     <a href="https://www.lightbend.com/legal/licenses" target="_blank">Licenses</a> |
                     <a href="https://www.lightbend.com/legal/terms" target="_blank">Terms</a> |
                     <a href="https://www.lightbend.com/legal/privacy" target="_blank">Privacy Policy</a> |

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -21,7 +21,7 @@
         <meta name="google-site-verification" content="9oxXjOc4jWfnf21Iep-0dc2sDawa14s-Gpwho_yb5AU" />
 
         <!-- OneTrust Cookies Consent Notice (Production Standard, playframework.com, en-GB) start -->
-        <script src="https://optanon.blob.core.windows.net/consent/cf9a6823-fec0-455d-b6c6-5f386804e808.js" type="text/javascript" charset="UTF-8"></script>
+        <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="f6af8492-c939-49d1-98d9-0b5cde6ce6d2" ></script>
         @views.html.helper.script(Symbol("type") -> "text/javascript") {
             function OptanonWrapper() {
                 //one trust inserts here


### PR DESCRIPTION
@ignasi35 @ennru 

This updates the Play Framework website to the latest cookie banner code. It uses geo-location to present Californian users with CCPA specific language in the preference center, cookie banner and footer link. The rest the world see's existing GDPR messaging. 

Also the preference center and cookie banner has a new look and feel as part of this upgrade, that all visitors will now see.

Example of the Preference center newer look:
![play-privacy](https://user-images.githubusercontent.com/1418129/104245516-44caf780-5419-11eb-9dc0-c0abc1b61057.png)

