### PR TITLE
Fix docs: change oracle jdk link to open jdk link

### DIFF
--- a/app/views/gettingStarted.scala.html
+++ b/app/views/gettingStarted.scala.html
@@ -33,7 +33,7 @@
                     <h3><span>&raquo;</span> Try the Hello World Tutorial</h3>
                     <div class="try-option-content">
                         <p>The Java and Scala Hello World projects are self-contained tutorials that include a distribution of the sbt build tool.</p>
-                        <p>Play requires Java 8 or higher. Check your version with the <code>java -version</code> command and if needed, install it from <a href="//www.oracle.com/technetwork/java/javase/downloads/index.html" rel="noopener">Oracle's site</a>.</p>
+                        <p>Play requires Java 8 or higher. Check your version with the <code>java -version</code> command and if needed, install it from <a href="https://adoptium.net/" rel="noopener">Adoptium</a>.</p>
                         <p>To try the tutorial, first download the Java or Scala project:</p>
                             <table>
                             @examples.sections.map { case (version, section) =>


### PR DESCRIPTION
Fixes #445

- This pull request changes a link to oracle JDK to open JDK on [Getting started page](https://www.playframework.com/getting-started). Issue is explained on playframework/playframework#10938.
- Related pull request was made on playframework/playframework#10982.
