### PR TITLE
Play 2.8.11 release

### DIFF
--- a/conf/playReleases.json
+++ b/conf/playReleases.json
@@ -1,14 +1,10 @@
 {
   "latest": {
-    "version": "2.8.10",
-    "date": "Nov 30 2021"
+    "version": "2.8.11",
+    "date": "Dec 1 2021"
   },
   "development": [],
   "previous": [
-    {
-    "version": "2.8.9",
-    "date": "Nov 25 2021"
-    },
     {
       "version": "2.8.8",
       "date": "Apr 8 2021"

--- a/public/markdown/changelog.md
+++ b/public/markdown/changelog.md
@@ -1,16 +1,10 @@
-## Play 2.8.10
 
-*Released 30 November 2021
+## Play 2.8.11
 
-[All changes](https://github.com/playframework/playframework/compare/2.8.9...2.8.10/)
+*Released 1 December 2021
+
+[All changes](https://github.com/playframework/playframework/compare/2.8.8...2.8.11/)
 [GitHub milestone](https://github.com/playframework/playframework/milestone/116?closed=1)
-
-## Play 2.8.9
-
-*Released 25 November 2021
-
-[All changes](https://github.com/playframework/playframework/compare/2.8.8...2.8.9/)
-[GitHub milestone](https://github.com/playframework/playframework/milestone/115?closed=1)
 
 ## Play 2.8.8
 


### PR DESCRIPTION
Updates the website for release 2.8.11. 

Note, that I removed 2.8.9 and 2.8.10 as I consider them invalid releases, better not to have them in the website to avoid confusion. 

* v2.8.9 had issue with play-ws and scala-java8-compat
* v2.8.10 was build using JDK11 (btw, 2.8.9 as well)

I moved all issues and PRs solved since 2.8.8 to milestone 2.8.11. 