### PR TITLE
Add e-mail contact for premium sponsors

### DIFF
--- a/app/views/sponsors.scala.html
+++ b/app/views/sponsors.scala.html
@@ -46,6 +46,9 @@
                     <li>Mention in every <a href="//github.com/playframework/playframework/releases">release announcement</a>, including your company logo.</li>
                     <li>"Thank you" tweet from <a href="//twitter.com/playframework">@@playframework</a></li>
                 </ul>
+                <p>
+                    If you have questions you can contact us at <a href="mailto:contact@@playframework.com">contact@@playframework.com</a>.
+                </p>
             </section>
             <section>
                 <h2>Who is responsible?</h2>


### PR DESCRIPTION
There is no way to contact us in private (you could send a message via opencollective, but not everyone is aware of that or finds the button).

<kbd><img width="600" src="https://user-images.githubusercontent.com/644927/150605392-5fd1e30d-d180-4a3f-899b-3b19d21c2f97.png" /></kbd>
