### PR TITLE
Remove old or broken book links from documentation sidebar.

### DIFF
--- a/app/views/documentation/v1.scala.html
+++ b/app/views/documentation/v1.scala.html
@@ -27,15 +27,6 @@
         <h3>Contents</h3>
         <div id="toc"></div>
 
-        <h3>Books</h3>
-
-        <p>
-            <a href="//www.packtpub.com/play-framework-cookbook/book"><img src="@routes.Assets.versioned("images/docs/play-framework-cookbook-cover.jpg")"></a>
-        </p>
-
-        <p>
-            <a href="http://www.the-play-book.co.uk/"><img src="@routes.Assets.versioned("images/docs/introducing-play-cover.gif")"></a> </li>
-        </p>
     </aside>
 
     <article>

--- a/app/views/documentation/v2.scala.html
+++ b/app/views/documentation/v2.scala.html
@@ -15,12 +15,6 @@
 
         @sidebar.map(Html.apply)
 
-        <h3>Books</h3>
-        <p><a title="Play Framework Essentials" href="http://www.lightbend.com/resources/e-book/play-framework-essentials"><img width="175" src="@routes.Assets.versioned("images/docs/play-framework-essentials-cover.jpg")"/></a></p>
-        <p><a title="Reactive Web Applications" href="http://info.lightbend.com/EBK-20XX-Reactive-Web-Applications-with-Play_L.html?lst=PPS&lsd=EBK-20XX-Reactive-Web-Applications-with-Play"><img width="175" src="@routes.Assets.versioned("images/docs/Reactive-Web-App-with-Play-Cover.jpg")"></a></p>
-        <p><a title="Play for Scala" href="http://lightbend.com/resources/e-book/play-for-scala"><img width="175" src="@routes.Assets.versioned("images/docs/play-for-scala-cover.jpg")"></a></p>
-        <p><a title="Play for Java" href="http://lightbend.com/resources/e-book/play-for-java"><img width="175" src="@routes.Assets.versioned("images/docs/play-for-java-cover.jpg")"></a></p>
-        <p><a title="Learning Play! Framework 2" href="http://www.packtpub.com/learning-play-framework-2/book"><img width="175" src="@routes.Assets.versioned("images/docs/learning-play-cover.jpg")"></a></p>
     </aside>
 
     <article>


### PR DESCRIPTION
It looks like the book links are broken or discontinued by their publishers. This PR simply removes this links to the books in the `aside`.

Feel free to reject this PR if it is not the right thing to do. 

Cheers! 