### PR TITLE
Switch to GitHub Discussions (+ rm outdated Google Groups)

### DIFF
--- a/app/assets/css/modules/_header.styl
+++ b/app/assets/css/modules/_header.styl
@@ -55,7 +55,7 @@
                 social(3)
             &[href*=stackoverflow]
                 social(4)
-            &[href*=discuss]
+            &[href*=discussions]
                 social(5)
             &[href*=opencollective]
                 social(6)

--- a/app/views/commonSidebar.scala.html
+++ b/app/views/commonSidebar.scala.html
@@ -11,8 +11,8 @@
 </ul>
 <@hn>Find help</@hn>
 <ul>
-    <li><a href="https://discuss.playframework.com">Discuss Play Forum</a></li>
-    <li><a href="//discord.gg/g5s2vtZ4Fa">Discord Server</a></li>
+    <li><a href="https://github.com/playframework/playframework/discussions">Discuss Play Forum</a></li>
+    <li><a href="https://discord.gg/g5s2vtZ4Fa">Discord Server</a></li>
     <li><a href="https://stackoverflow.com/questions/tagged/playframework">Stack Overflow</a></li>
 </ul>
 <@hn>Contribute</@hn>

--- a/app/views/documentation/v2.scala.html
+++ b/app/views/documentation/v2.scala.html
@@ -38,7 +38,7 @@
                   @Html(messages("documentation.contribute.message",
                       s"""<a href="$source">""", "</a>",
                       s"""<a href="${reverseRouter.latest(context.alternateLang, "Documentation")}">""", "</a>",
-                      s"""<a href="https://discuss.playframework.com/">""", "</a>"
+                      s"""<a href="https://github.com/playframework/playframework/discussions">""", "</a>"
                   )(context.lang))
               </p>
             }

--- a/app/views/getInvolved.scala.html
+++ b/app/views/getInvolved.scala.html
@@ -28,7 +28,7 @@
 
                 <h3 class="mailing">Join the Discuss Play forum</h3>
                 <p>
-                    The <a href="//discuss.playframework.com"><span class="mailingList">Discuss Play Forum</span></a> is where the Play community meets. Asking and answering questions on the discuss forum is a great way to share knowledge about Play.
+                    The <a href="//github.com/playframework/playframework/discussions"><span class="mailingList">Discuss Play Forum</span></a> is where the Play community meets. Asking and answering questions on the discuss forum is a great way to share knowledge about Play.
                 </p>
 
                 <h3 class="discord">Join the Discord chat</h3>
@@ -55,7 +55,7 @@
                 <h3 class="patch">Patch the core</h3>
                 <a href="//github.com/playframework/playframework/graphs/contributors">900+ committers</a>
                 <p>
-                    Play's code and documentation is hosted on <a href="//github.com/playframework/playframework">GitHub</a>. It's easy to <a href="@reverseRouter.latest(None, "BuildingFromSource")">get the code and build Play from source</a>. Play development is discussed on the <a href="//groups.google.com/forum/#!forum/play-framework-dev"><span class="mailingList">play-framework-dev</span> mailing list</a>. You can ask on the list if you have any questions, or you can also chat to Play contributors through the <a href="//discord.gg/g5s2vtZ4Fa">play-contributors</a> channel.
+                    Play's code and documentation is hosted on <a href="//github.com/playframework/playframework">GitHub</a>. It's easy to <a href="@reverseRouter.latest(None, "BuildingFromSource")">get the code and build Play from source</a>. Play development is discussed in the <a href="//github.com/playframework/playframework/discussions"><span class="mailingList">GitHub Discussions</span> forum</a>. You can ask on the list if you have any questions, or you can also chat to Play contributors through the <a href="//discord.gg/g5s2vtZ4Fa">play-contributors</a> channel.
                 </p>
                 <p>
                     You're welcome to work on any feature you like&mdash;Play is open source after all!&mdash;but if you'd like some good ideas, look for issues tagged with the <a href="//github.com/playframework/playframework/issues?labels=community"><span class="issueLabel">community label</a>. These issues are ready and waiting for volunteers to pick them up.

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -41,7 +41,7 @@
 
             <div id="tutorials">
                 <h2>Get Involved</h2>
-                <a href='//discuss.playframework.com' class="button">Join the Discuss<br/>Play Forum</a>
+                <a href='//github.com/playframework/playframework/discussions' class="button">Join the Discuss<br/>Play Forum</a>
                 <p>
                   Join <a href="//discord.gg/g5s2vtZ4Fa">Play's Discord server</a> and <a href="//stackoverflow.com/questions/tagged/playframework">Stack Overflow</a>
                 </p>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -58,7 +58,7 @@
                 </nav>
                 <nav id="social">
                     <a href="//opencollective.com/playframework"><span>Open Collective</span></a>
-                    <a href="//discuss.playframework.com"><span>Discuss Play Forum</span></a>
+                    <a href="//github.com/playframework/playframework/discussions"><span>Discuss Play Forum</span></a>
                     <a href="//discord.gg/g5s2vtZ4Fa"><span>Play Discord Server</span></a>
                     <a href="//twitter.com/playframework"><span>Twitter</span></a>
                     <a href="//github.com/playframework/playframework"><span>GitHub</span></a>
@@ -118,7 +118,7 @@
                 <article class="community">
                     <h3>Community support</h3>
                     <ul>
-                        <li><a href="//discuss.playframework.com">Discuss Forum</a></li>
+                        <li><a href="//github.com/playframework/playframework/discussions">Discuss Forum</a></li>
                         <li><a href="//discord.gg/g5s2vtZ4Fa">Discord</a></li>
                         <li><a href="//stackoverflow.com/questions/tagged/playframework">Stackoverflow</a></li>
                     </ul>

--- a/app/views/modules/list.scala.html
+++ b/app/views/modules/list.scala.html
@@ -8,7 +8,7 @@
     
     <blockquote>
         <p>
-            These modules are for the <strong>Play 1.x</strong> series only and are now read-only.  If you really need to provide an update, email the <a href="//groups.google.com/group/play-framework-dev">play-framework-dev</a> group.
+            These modules are for the <strong>Play 1.x</strong> series only and are now read-only.  If you really need to provide an update, let us know via the <a href="//github.com/playframework/playframework/discussions">Play Framework Forum</a>.
         </p>
         <p>
             <strong>Play 2.0</strong> modules can be hosted anywhere on any Ivy, Maven or Git repository.

--- a/public/markdown/community-process.md
+++ b/public/markdown/community-process.md
@@ -29,8 +29,8 @@ A contributor is anyone that makes a contribution to Play.  This does not necess
 * Writing or maintaining plugins, modules or libraries for Play
 * Code reviews in GitHub
 * Raising, triaging and adding additional information to help resolve issues
-* Taking part in design and feature discussions on mailing lists
-* Answering questions on mailing lists and in stack overflow
+* Taking part in design and feature discussions in the Discuss forum
+* Answering questions in the Discuss forum and in stack overflow
 * Running, speaking at or contributing to user groups focussed on Play Framework
 * Speaking at conferences, blogging about or otherwise promoting Play Framework
 
@@ -65,7 +65,7 @@ Whether a pull request is merged or not depends on many factors, including:
 
 ### Design and house keeping decisions
 
-The primary place for discussion about the design of Play and how the Play project is run is the [play-framework-dev](https://groups.google.com/forum/#!forum/play-framework-dev) mailing list.  All major new features, refactorings or changes to the project should first be discussed in this forum.  The aim of the discussions is to reach an understanding on whether the task will be done, and how it will be done.  When a new topic is posted, interested parties are encouraged to comment with their affirmation or concerns.
+The primary place for discussion about the design of Play and how the Play project is run is the [Play Framework Forum](https://github.com/playframework/playframework/discussions).  All major new features, refactorings or changes to the project should first be discussed in this forum.  The aim of the discussions is to reach an understanding on whether the task will be done, and how it will be done.  When a new topic is posted, interested parties are encouraged to comment with their affirmation or concerns.
 
 While Lightbend ultimately has the last word on all decisions here, as much as possible we will endeavor to reach a consensus in the majority of the community.
 
@@ -91,5 +91,5 @@ All integrators should follow the processes outlined on this page, and should be
 * An integrator must never merge their own pull requests.  All pull requests must be reviewed and merged by another integrator.
 * Documentation changes may be backported between releases as desired, however all other changes must by approved by Lightbend.
 * Integrators must enforce Lightbend's CLA requirements when merging pull requests.
-* When closing issues or pull requests, remember that we are dealing with people.  Be kind and helpful, pointing people in the right direction.  For example, if someone raises an issue that is really a question, when closing the issue, direct them to the mailing list, providing a link to the mailing list, and if possible, a brief answer to the question.
+* When closing issues or pull requests, remember that we are dealing with people.  Be kind and helpful, pointing people in the right direction.  For example, if someone raises an issue that is really a question, when closing the issue, direct them to the [Play Framework Forum](https://github.com/playframework/playframework/discussions) and if possible, a brief answer to the question.
 

--- a/public/markdown/contributing.md
+++ b/public/markdown/contributing.md
@@ -5,8 +5,8 @@
 If you wish to report an issue for Play Framework, please ensure you have done the following things:
 
 * If it is a documentation issue with a simple fix, don't raise an issue, just edit the documentation yourself directly in GitHub and submit a pull request.  This will be quicker for you and everybody.
-* If you are not 100% sure that it is a bug, then ask about it on the [Play Framework Forum](https://discuss.playframework.com) first.  You will get a lot more help a lot quicker on the mailing list if you raise it there.  The issue tracker is for verified bugs, not for questions.
-* If you have a feature request, please raise it on the [developer mailing list](https://groups.google.com/forum/#!forum/play-framework-dev) first.  The mailing list is the best forum to discuss new features, and it may be that Play already provides something to achieve what you want to achieve and you didn't realise.
+* If you are not 100% sure that it is a bug, then ask about it in the [Play Framework Forum](https://github.com/playframework/playframework/discussions) first.  You will get a lot more help a lot quicker in the forum if you raise it there.  The issue tracker is for verified bugs, not for questions.
+* If you have a feature request, please also raise it in the [GitHub Discussion forum](https://github.com/playframework/playframework/discussions) first.  The forum is the best place to discuss new features, and it may be that Play already provides something to achieve what you want to achieve and you didn't realise.
 * If you are sure you have found a bug, then raise an issue.  Please be as specific as possible, including sample code that reproduces the problem, stack traces if there are any exceptions thrown, and versions of Play, OS, Java, etc.
 
 When the above guidelines are not followed, a Play integrator may close the issue, directing you to the appropriate forum for further discussion.
@@ -15,7 +15,7 @@ When the above guidelines are not followed, a Play integrator may close the issu
 
 ### Prerequisites
 
-Before making a contribution, it is important to make sure that the change you wish to make and the approach you wish to take will likely be accepted, otherwise you may end up doing a lot of work for nothing.  If the change is only small, for example, if it's a documentation change or a simple bugfix, then it's likely to be accepted with no prior discussion.  However, new features, or bigger refactorings should first be discussed on the [developer mailing list](https://groups.google.com/forum/#!forum/play-framework-dev).  Additionally, any issues with the [community label](https://github.com/playframework/playframework/issues?q=is%3Aopen+is%3Aissue+label%3Acommunity) have been agreed to be a change that will likely be accepted.
+Before making a contribution, it is important to make sure that the change you wish to make and the approach you wish to take will likely be accepted, otherwise you may end up doing a lot of work for nothing.  If the change is only small, for example, if it's a documentation change or a simple bugfix, then it's likely to be accepted with no prior discussion.  However, new features, or bigger refactorings should first be discussed in the [Play Framework Forum](https://github.com/playframework/playframework/discussions).  Additionally, any issues with the [community label](https://github.com/playframework/playframework/issues?q=is%3Aopen+is%3Aissue+label%3Acommunity) have been agreed to be a change that will likely be accepted.
 
 ### Procedure
 


### PR DESCRIPTION
Just replacing links.
There were also places were the old google groups mailing list still was used.
Tested locally.