### PR TITLE
Make sure remote of the cloned repo is called "origin" + add .gitconfig tip to README

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -41,7 +41,7 @@ jobs:
       scala: 2.13.x
       cmd: |
         # Clone generated docs so that we can run some integration tests
-        git clone https://github.com/playframework/play-generated-docs.git $PWD/data/generated
+        git clone -o origin https://github.com/playframework/play-generated-docs.git $PWD/data/generated
         sbt ++$MATRIX_SCALA test
 
   finish:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 Requirements for full installation:
 - local clone of playframework, with remote called origin, symlinked from data/main.
 - local clone of play-generated-docs, with remote called origin, symlinked from data/generated.
-  - `git clone https://github.com/playframework/play-generated-docs.git $PWD/data/generated`
+  - `git clone -o origin https://github.com/playframework/play-generated-docs.git $PWD/data/generated`
 - local clone of each doc translation in data/translationname, e.g. data/ja, data/tr, data/fr, data/bg. See application.conf for list of translation repos.
 
 Git should ignore the symlinked repos but you may need to tell your IDE to exclude them.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Requirements for full installation:
 - local clone of play-generated-docs, with remote called origin, symlinked from data/generated.
   - `git clone -o origin https://github.com/playframework/play-generated-docs.git $PWD/data/generated`
 - local clone of each doc translation in data/translationname, e.g. data/ja, data/tr, data/fr, data/bg. See application.conf for list of translation repos.
+- If you run tests locally, you might want to temporary move your $HOME/.gitconfig file to have a "clean" environment, like `mv .gitconfig .gitconfig.bak`. That's because JGit is used and by default reads that user config file. This can cause problems when running tests, e.g. when you have signing activated in your ~/.gitconfig file. Unfortunatly there is no config nor env-varible to disable reading that config file, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=488777
 
 Git should ignore the symlinked repos but you may need to tell your IDE to exclude them.
 


### PR DESCRIPTION
My `clone.defaultRemoteName` is set to `upstream` in my `~/.gitconfig`, so the tests didn't work because they read from the `origin` remote by default....