### PR TITLE
Fix link to point to play-samples

### DIFF
--- a/app/views/gettingStarted.scala.html
+++ b/app/views/gettingStarted.scala.html
@@ -62,7 +62,7 @@
 
             <div class="try-section">
                 <h2>Already know a bit about Play?</h2>
-                <p>Lightbend offers a variety of <a href="https://www.lightbend.com/akka-platform/developers#example-projects">Play example projects for Java and Scala</a> that are focused on a particular use case. These include everything you need, including <a href="//www.scala-sbt.org/index.html">sbt</a>, Play Framework, and an HTTP server. The examples also support <a href="//docs.gradle.org/current/userguide/play_plugin.html">Gradle</a>.</p>
+                <p>There are a variety of <a href="https://github.com/playframework/play-samples">Play example projects for Java and Scala</a> that are focused on a particular use case. These include everything you need, including <a href="//www.scala-sbt.org/index.html">sbt</a>, Play Framework, and an HTTP server. The examples also support <a href="//docs.gradle.org/current/userguide/play_plugin.html">Gradle</a>.</p>
                 <p>If you are ready to start your own project and have sbt installed, you can create a Play project from the command line.</p>
 
                 <div class="try-option">


### PR DESCRIPTION
Link to Lightbend sample projects actually pointed to Akka.

This is a bit tough to spot because it's outside of play-doc.  Probably better to move play-doc in its entirety to playframework.com and retire the inline documentation feature -- it never worked very well.