### PR TITLE
Fix the name of the Bulgarian language

### DIFF
--- a/conf/messages.bg
+++ b/conf/messages.bg
@@ -1,4 +1,4 @@
-lang.name=българин
+lang.name=български
 
 documentation.contribute.message=Found an error in this documentation? The source code for this page can be found \
   {0}here{1}.  After reading the {2}documentation guidelines{3}, please feel free to contribute a pull request.

--- a/conf/messages.bg
+++ b/conf/messages.bg
@@ -1,4 +1,4 @@
-lang.name=български
+lang.name=Български
 
 documentation.contribute.message=Found an error in this documentation? The source code for this page can be found \
   {0}here{1}.  After reading the {2}documentation guidelines{3}, please feel free to contribute a pull request.


### PR DESCRIPTION
The previous value, ‘българин’, means ‘a Bulgarian person’, or ‘a Bulgarian man’. The name of the language should be ‘български’.

This PR also capitalizes the language name. In Bulgarian, the language name is not a proper name and I can be all lowercase, but the same is true for French. Since French is capitalized, as well as English and Turkish (where it's a proper name), it looks visually better if all language names are capitalized (as if they were at the beginning of the sentence). This is how Wikipedia does it, for example.