### PR TITLE
Group Scala Steward patch updates into single PR

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,7 +1,7 @@
 pullRequests.frequency = "@monthly"
 
-updates.ignore = [ 
-  { groupId = "org.scalameta", artifactId = "scalafmt-core" } 
-]
-
 commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"
+
+pullRequests.grouping = [
+  { name = "patches", "title" = "Patch updates", "filter" = [{"version" = "patch"}] }
+]


### PR DESCRIPTION
Patch updates are likey to not break anything so we can just put them into one PR.