### PR TITLE
Migrate away from example.lightbend.com webservice

### DIFF
--- a/app/models/PlayExampleProjects.scala
+++ b/app/models/PlayExampleProjects.scala
@@ -31,7 +31,6 @@ object TemplateParameter {
 
 case class ExampleProject(
     displayName: String,
-    downloadUrl: String,
     gitHubRepo: String,
     gitHubUrl: String,
     keywords: Seq[String],

--- a/app/models/PlayExampleProjects.scala
+++ b/app/models/PlayExampleProjects.scala
@@ -2,8 +2,11 @@ package models
 
 import com.google.inject.AbstractModule
 import com.google.inject.Singleton
+import org.apache.commons.io.IOUtils
+
 import javax.inject.Inject
 import play.api.Configuration
+import play.api.Environment
 import play.api.cache.SyncCacheApi
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
@@ -54,13 +57,14 @@ class PlayExampleProjectsService @Inject() (
     configuration: Configuration,
     ws: WSClient,
     cache: SyncCacheApi,
+    environment: Environment
 )(implicit ec: ExecutionContext) {
 
   val validPlayVersions: Seq[String] = configuration.get[Seq[String]]("examples.playVersions")
 
   private val logger = org.slf4j.LoggerFactory.getLogger(this.getClass)
 
-  private val examplesUrl = configuration.get[String]("examples.apiUrl")
+  //private val examplesUrl = configuration.get[String]("examples.apiUrl")
 
   // NOTE: TTL is really just a safety measure here.
   // We should re-deploy when we make major changes to projects
@@ -89,12 +93,19 @@ class PlayExampleProjectsService @Inject() (
 
   def examples(): Future[Seq[ExampleProject]] = {
     Future
-      .sequence(validPlayVersions.map { version =>
-        ws.url(examplesUrl)
-          .withQueryStringParameters(playQueryString(version): _*)
-          .get()
-          .map(response => (version, response.json))
-      })
+      .sequence(validPlayVersions.map { version => {
+        lazy val samples: JsValue =
+          environment
+            .resourceAsStream(s"playSamples_${version}.json")
+            .flatMap { is =>
+              try {
+                Json.fromJson[JsValue](Json.parse(IOUtils.toByteArray(is))).asOpt
+              } finally {
+                is.close()
+              }
+            }.getOrElse(JsArray())
+        Future.successful(version, samples)
+      }})
       .map { response =>
         response.flatMap((convertExampleProjects _).tupled)
       }

--- a/app/views/gettingStarted.scala.html
+++ b/app/views/gettingStarted.scala.html
@@ -3,7 +3,7 @@
 
 @renderProject(project: ExampleProject) = {
     <tr>
-        <td><a href="@project.downloadUrl" target="_blank">@project.displayName</a></td>
+        <td>@project.displayName</td>
         <td><a href="@project.gitHubUrl" target="_blank">View on GitHub</a></td>
     </tr>
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -33,7 +33,8 @@ github.apiUrl = "https://api.github.com"
 opencollective.restApiUrl = "https://opencollective.com/"
 opencollective.slug = "playframework"
 
-examples.apiUrl = "https://example.lightbend.com/v1/api/templates"
+# apiUrl not used currently, we use local json files in conf/playSamples_x.x.x.json currently
+#examples.apiUrl = "https://example.lightbend.com/v1/api/templates"
 examples.playVersions = [ "2.8.x" ]
 examples.cache.ttl = 1 hour
 

--- a/conf/playSamples_2.8.x.json
+++ b/conf/playSamples_2.8.x.json
@@ -19,7 +19,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-macwire-di-example",
     "summary": "Sample project for compile-time DI with Macwire"
   },
   {
@@ -42,7 +41,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-compile-di-example",
     "summary": "Example Play Project using compile time dependency injection and Play WS with ScalaTest"
   },
   {
@@ -64,7 +62,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-compile-di-example",
     "summary": "Play application using compile time DI with Java API"
   },
   {
@@ -87,7 +84,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-dagger2-example",
     "summary": "Play Application using Dagger 2 for Compile Time DI"
   },
   {
@@ -109,7 +105,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-chatroom-example",
     "summary": "A simple chatroom using Play and Websockets with the Java API.",
     "description": "This is a simple chatroom using Play and Websockets with the Java API.<br>This project makes use of<a href=\"http://doc.akka.io/docs/akka/current/java/stream/stream-dynamic.html\">dynamic streams</a> from Akka Streams, notably <code>BroadcastHub</code> and <code>MergeHub</code>.  By <a href=\"http://doc.akka.io/docs/akka/current/java/stream/stream-dynamic.html#Dynamic_fan-in_and_fan-out_with_MergeHub_and_BroadcastHub\">combining MergeHub and BroadcastHub</a>, you can get publish/subscribe functionality."
   },
@@ -132,7 +127,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-chatroom-example",
     "summary": "A simple chatroom using Play and Websockets with the Scala API.",
     "description": "This is a simple chatroom using Play and Websockets with the Scala API.<br>This project makes use of<a href=\"http://doc.akka.io/docs/akka/current/scala/stream/stream-dynamic.html\">dynamic streams</a> from Akka Streams, notably <code>BroadcastHub</code> and <code>MergeHub</code>.  By <a href=\"http://doc.akka.io/docs/akka/current/scala/stream/stream-dynamic.html#Dynamic_fan-in_and_fan-out_with_MergeHub_and_BroadcastHub\">combining MergeHub and BroadcastHub</a>, you can get publish/subscribe functionality."
   },
@@ -157,7 +151,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-streaming-example",
     "summary": "This is an example Play template that demonstrates Streaming with Server Sent Events or Comet, using Akka Streams."
   },
   {
@@ -181,7 +174,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-streaming-example",
     "summary": "This is an example Play template that demonstrates Streaming with Server Sent Events or Comet, using Akka Streams."
   },
   {
@@ -204,7 +196,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-websocket-example",
     "summary": "An example Play application that shows how to use Play's Websocket API in Java, by showing a series of stock tickers updated using WebSocket.",
     "description": "The Websocket API is built on Akka Streams, and so is async, non-blocking, and backpressure aware. Using Akka Streams also means that interacting with Akka Actors is simple.<br>There are also tests showing how Junit and Akka Testkit are used to test actors and flows."
   },
@@ -228,7 +219,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-websocket-example",
     "summary": "An example Play application that shows how to use Play's Websocket API in Scala, by showing a series of stock tickers updated using WebSocket.",
     "description": "The Websocket API is built on Akka Streams, and so is async, non-blocking, and backpressure aware. Using Akka Streams also means that interacting with Akka Actors is simple.<br>There are also tests showing how Junit and Akka Testkit are used to test actors and flows."
   },
@@ -252,7 +242,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-fileupload-example",
     "summary": "A sample project that shows how to upload a file through Akka Streams using a custom BodyParser using Akka Streams using the Java API."
   },
   {
@@ -275,7 +264,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-fileupload-example",
     "summary": "A sample project that shows how to upload a file through Akka Streams using a custom BodyParser using Akka Streams and the Scala API."
   },
   {
@@ -297,7 +285,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-starter-example",
     "summary": "A starter application that shows how Play works.",
     "description": "This is a starter application that shows how Play works.  Please see the documentation at <a href=\"https://www.playframework.com/documentation/latest/Home\">https://www.playframework.com/documentation/latest/Home</a> for more details."
   },
@@ -320,7 +307,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-starter-example",
     "summary": "A starter application that shows how Play works.",
     "description": "This is a starter application that shows how Play works.  Please see the documentation at <a href=\"https://www.playframework.com/documentation/latest/Home\">https://www.playframework.com/documentation/latest/Home</a> for more details."
   },
@@ -345,7 +331,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-anorm-example",
     "summary": "An example Play application that uses Scala on the front end, and communicates with an in memory database using Anorm."
   },
   {
@@ -370,7 +355,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-jpa-example",
     "summary": "This project demonstrate how to create a simple CRUD application with Play, using JPA."
   },
   {
@@ -394,7 +378,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-ebean-example",
     "summary": "An example Play application that uses Java, and communicates with an in memory database using EBean."
   },
   {
@@ -416,7 +399,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-rest-api-example",
     "summary": "Example project for making a REST API in Play using the Scala API."
   },
   {
@@ -438,7 +420,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-rest-api-example",
     "summary": "Example project for making a REST API in Play using the Java API."
   },
   {
@@ -460,7 +441,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-forms-example",
     "summary": "Example project for doing forms processing in Play in the Scala API."
   },
   {
@@ -482,7 +462,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-forms-example",
     "summary": "Example project for doing forms processing in Play in the Java API."
   },
   {
@@ -506,7 +485,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-tls-example",
     "summary": "This application shows how to use Play with SSL/TLS, using the Java Secure Socket Extension (JSSE) API."
   },
   {
@@ -530,7 +508,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-secure-session-example",
     "summary": "An example Play application showing encrypted session management",
     "description": "This is an example application that shows how to use symmetric encryption with <a href=\"https://github.com/abstractj/kalium/\">Kalium</a></br>You must install libsodium before using this application.  If you have homebrew, you can use <code>brew install libsodium</code>."
   },
@@ -554,7 +531,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-hello-world-tutorial",
     "summary": "Play Hello World tutorial in Scala",
     "description": "This tutorial introduces Play Framework, describes how Play web applications work, and walks you through steps to create page that displays a Hello World greeting.",
     "featured": {
@@ -581,7 +557,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-hello-world-tutorial",
     "summary": "Play Hello World tutorial in Java",
     "description": "This tutorial introduces Play Framework, describes how Play web applications work, and walks you through steps to create page that displays a Hello World greeting."
   },
@@ -604,7 +579,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-grpc-example",
     "summary": "A starter application that shows how to use gRPC within a Play app.",
     "description": "This is an example applicaiton shows how to use gRPC in Play.  Please see the documentation at <a href=\"https://developer.lightbend.com/guides/play-scala-grpc-example/\">https://developer.lightbend.com/guides/play-scala-grpc-example/</a> for more details."
   },
@@ -627,7 +601,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-grpc-example",
     "summary": "A starter application that shows how to use gRPC within a Play app.",
     "description": "This is an example applicaiton shows how to use gRPC in Play.  Please see the documentation at <a href=\"https://developer.lightbend.com/guides/play-scala-grpc-example/\">https://developer.lightbend.com/guides/play-scala-grpc-example/</a> for more details."
   },
@@ -650,7 +623,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-scala-seed",
     "summary": "Play Scala Seed Project",
     "description": "This is a seed project which creates a basic build for a Play application. It doesn't include a tutorial or demonstration, it's just a minimal project to start your own application from.",
     "parameters": [
@@ -684,7 +656,6 @@
         "name": "2.8.x"
       }
     },
-    "downloadUrl": "https://example.lightbend.com/v1/download/play-java-seed",
     "summary": "Play Java Seed Project",
     "description": "This is a seed project which creates a basic build for a Play application. It doesn't include a tutorial or demonstration, it's just a minimal project to start your own application from.",
     "parameters": [

--- a/conf/playSamples_2.8.x.json
+++ b/conf/playSamples_2.8.x.json
@@ -1,0 +1,702 @@
+[
+  {
+    "displayName": "Play Scala Dependency Injection using Macwire Example",
+    "templateName": "play-samples-play-scala-macwire-di-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-scala-macwire-di-example",
+    "keywords": [
+      "play",
+      "scala",
+      "macwire",
+      "di",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-macwire-di-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-macwire-di-example",
+    "summary": "Sample project for compile-time DI with Macwire"
+  },
+  {
+    "displayName": "Play Scala Compile Time Dependency Injection Example",
+    "templateName": "play-samples-play-scala-compile-di-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-scala-compile-di-example",
+    "keywords": [
+      "play",
+      "scala",
+      "di",
+      "scalatest",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-compile-di-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-compile-di-example",
+    "summary": "Example Play Project using compile time dependency injection and Play WS with ScalaTest"
+  },
+  {
+    "displayName": "Play Java Compile Time Dependency Injection Example",
+    "templateName": "play-samples-play-java-compile-di-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-java-compile-di-example",
+    "keywords": [
+      "play",
+      "java",
+      "di",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-java-compile-di-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-compile-di-example",
+    "summary": "Play application using compile time DI with Java API"
+  },
+  {
+    "displayName": "Play Java using Dagger 2 for Compile Time DI",
+    "templateName": "play-samples-play-java-dagger2-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-java-dagger2-example",
+    "keywords": [
+      "play",
+      "java",
+      "di",
+      "dagger2",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-java-dagger2-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-dagger2-example",
+    "summary": "Play Application using Dagger 2 for Compile Time DI"
+  },
+  {
+    "displayName": "Play Java Chatroom using Websockets Example",
+    "templateName": "play-samples-play-java-chatroom-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-java-chatroom-example",
+    "keywords": [
+      "play",
+      "java",
+      "websocket",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-java-chatroom-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-chatroom-example",
+    "summary": "A simple chatroom using Play and Websockets with the Java API.",
+    "description": "This is a simple chatroom using Play and Websockets with the Java API.<br>This project makes use of<a href=\"http://doc.akka.io/docs/akka/current/java/stream/stream-dynamic.html\">dynamic streams</a> from Akka Streams, notably <code>BroadcastHub</code> and <code>MergeHub</code>.  By <a href=\"http://doc.akka.io/docs/akka/current/java/stream/stream-dynamic.html#Dynamic_fan-in_and_fan-out_with_MergeHub_and_BroadcastHub\">combining MergeHub and BroadcastHub</a>, you can get publish/subscribe functionality."
+  },
+  {
+    "displayName": "Play Scala Chatroom using Websockets Example",
+    "templateName": "play-samples-play-scala-chatroom-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-scala-chatroom-example",
+    "keywords": [
+      "play",
+      "scala",
+      "websocket",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-chatroom-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-chatroom-example",
+    "summary": "A simple chatroom using Play and Websockets with the Scala API.",
+    "description": "This is a simple chatroom using Play and Websockets with the Scala API.<br>This project makes use of<a href=\"http://doc.akka.io/docs/akka/current/scala/stream/stream-dynamic.html\">dynamic streams</a> from Akka Streams, notably <code>BroadcastHub</code> and <code>MergeHub</code>.  By <a href=\"http://doc.akka.io/docs/akka/current/scala/stream/stream-dynamic.html#Dynamic_fan-in_and_fan-out_with_MergeHub_and_BroadcastHub\">combining MergeHub and BroadcastHub</a>, you can get publish/subscribe functionality."
+  },
+  {
+    "displayName": "Play Java Streaming Example",
+    "templateName": "play-samples-play-java-streaming-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-java-streaming-example",
+    "keywords": [
+      "play",
+      "java",
+      "streaming",
+      "sse",
+      "comet",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-java-streaming-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-streaming-example",
+    "summary": "This is an example Play template that demonstrates Streaming with Server Sent Events or Comet, using Akka Streams."
+  },
+  {
+    "displayName": "Play Scala Streaming Example",
+    "templateName": "play-samples-play-scala-streaming-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-scala-streaming-example",
+    "keywords": [
+      "play",
+      "scala",
+      "streaming",
+      "sse",
+      "comet",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-streaming-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-streaming-example",
+    "summary": "This is an example Play template that demonstrates Streaming with Server Sent Events or Comet, using Akka Streams."
+  },
+  {
+    "displayName": "Play Java Websocket Example",
+    "templateName": "play-samples-play-java-websocket-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-java-websocket-example",
+    "keywords": [
+      "play",
+      "java",
+      "websocket",
+      "actor",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-java-websocket-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-websocket-example",
+    "summary": "An example Play application that shows how to use Play's Websocket API in Java, by showing a series of stock tickers updated using WebSocket.",
+    "description": "The Websocket API is built on Akka Streams, and so is async, non-blocking, and backpressure aware. Using Akka Streams also means that interacting with Akka Actors is simple.<br>There are also tests showing how Junit and Akka Testkit are used to test actors and flows."
+  },
+  {
+    "displayName": "Play Scala Websocket Example",
+    "templateName": "play-samples-play-scala-websocket-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-scala-websocket-example",
+    "keywords": [
+      "play",
+      "scala",
+      "websocket",
+      "actor",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-websocket-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-websocket-example",
+    "summary": "An example Play application that shows how to use Play's Websocket API in Scala, by showing a series of stock tickers updated using WebSocket.",
+    "description": "The Websocket API is built on Akka Streams, and so is async, non-blocking, and backpressure aware. Using Akka Streams also means that interacting with Akka Actors is simple.<br>There are also tests showing how Junit and Akka Testkit are used to test actors and flows."
+  },
+  {
+    "displayName": "Play Java File Upload Example",
+    "templateName": "play-samples-play-java-fileupload-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-java-fileupload-example",
+    "keywords": [
+      "play",
+      "java",
+      "upload",
+      "multipart",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-java-fileupload-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-fileupload-example",
+    "summary": "A sample project that shows how to upload a file through Akka Streams using a custom BodyParser using Akka Streams using the Java API."
+  },
+  {
+    "displayName": "Play Scala File Upload Example",
+    "templateName": "play-samples-play-scala-fileupload-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-scala-fileupload-example",
+    "keywords": [
+      "play",
+      "scala",
+      "upload",
+      "multipart",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-fileupload-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-fileupload-example",
+    "summary": "A sample project that shows how to upload a file through Akka Streams using a custom BodyParser using Akka Streams and the Scala API."
+  },
+  {
+    "displayName": "Play Scala Starter Example",
+    "templateName": "play-samples-play-scala-starter-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-scala-starter-example",
+    "keywords": [
+      "play",
+      "scala",
+      "starter",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-starter-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-starter-example",
+    "summary": "A starter application that shows how Play works.",
+    "description": "This is a starter application that shows how Play works.  Please see the documentation at <a href=\"https://www.playframework.com/documentation/latest/Home\">https://www.playframework.com/documentation/latest/Home</a> for more details."
+  },
+  {
+    "displayName": "Play Java Starter Example",
+    "templateName": "play-samples-play-java-starter-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-java-starter-example",
+    "keywords": [
+      "play",
+      "java",
+      "starter",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-java-starter-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-starter-example",
+    "summary": "A starter application that shows how Play works.",
+    "description": "This is a starter application that shows how Play works.  Please see the documentation at <a href=\"https://www.playframework.com/documentation/latest/Home\">https://www.playframework.com/documentation/latest/Home</a> for more details."
+  },
+  {
+    "displayName": "Play Scala Anorm Example",
+    "templateName": "play-samples-play-scala-anorm-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-scala-anorm-example",
+    "keywords": [
+      "play",
+      "scala",
+      "anorm",
+      "database",
+      "orm",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-anorm-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-anorm-example",
+    "summary": "An example Play application that uses Scala on the front end, and communicates with an in memory database using Anorm."
+  },
+  {
+    "displayName": "Play Java JPA Example",
+    "templateName": "play-samples-play-java-jpa-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-java-jpa-example",
+    "keywords": [
+      "play",
+      "java",
+      "jpa",
+      "hibernate",
+      "orm",
+      "database",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-java-jpa-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-jpa-example",
+    "summary": "This project demonstrate how to create a simple CRUD application with Play, using JPA."
+  },
+  {
+    "displayName": "Play Java Ebean Example",
+    "templateName": "play-samples-play-java-ebean-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-java-ebean-example",
+    "keywords": [
+      "play",
+      "java",
+      "ebean",
+      "database",
+      "orm",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-java-ebean-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-ebean-example",
+    "summary": "An example Play application that uses Java, and communicates with an in memory database using EBean."
+  },
+  {
+    "displayName": "Play Scala REST API Example",
+    "templateName": "play-samples-play-scala-rest-api-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-scala-rest-api-example",
+    "keywords": [
+      "play",
+      "scala",
+      "rest",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-rest-api-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-rest-api-example",
+    "summary": "Example project for making a REST API in Play using the Scala API."
+  },
+  {
+    "displayName": "Play Java REST API Example",
+    "templateName": "play-samples-play-java-rest-api-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-java-rest-api-example",
+    "keywords": [
+      "play",
+      "java",
+      "rest",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-java-rest-api-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-rest-api-example",
+    "summary": "Example project for making a REST API in Play using the Java API."
+  },
+  {
+    "displayName": "Play Scala Forms Example",
+    "templateName": "play-samples-play-scala-forms-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-scala-forms-example",
+    "keywords": [
+      "play",
+      "scala",
+      "forms",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-forms-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-forms-example",
+    "summary": "Example project for doing forms processing in Play in the Scala API."
+  },
+  {
+    "displayName": "Play Java Forms Example",
+    "templateName": "play-samples-play-java-forms-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-java-forms-example",
+    "keywords": [
+      "play",
+      "java",
+      "forms",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-java-forms-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-forms-example",
+    "summary": "Example project for doing forms processing in Play in the Java API."
+  },
+  {
+    "displayName": "Play Secure HTTP (SSL/TLS) Example",
+    "templateName": "play-samples-play-scala-tls-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-scala-tls-example",
+    "keywords": [
+      "play",
+      "scala",
+      "https",
+      "ssl",
+      "tls",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-tls-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-tls-example",
+    "summary": "This application shows how to use Play with SSL/TLS, using the Java Secure Socket Extension (JSSE) API."
+  },
+  {
+    "displayName": "Play Scala Secure Session Example",
+    "templateName": "play-samples-play-scala-secure-session-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-scala-secure-session-example",
+    "keywords": [
+      "play",
+      "scala",
+      "kalium",
+      "encryption",
+      "session",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-secure-session-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-secure-session-example",
+    "summary": "An example Play application showing encrypted session management",
+    "description": "This is an example application that shows how to use symmetric encryption with <a href=\"https://github.com/abstractj/kalium/\">Kalium</a></br>You must install libsodium before using this application.  If you have homebrew, you can use <code>brew install libsodium</code>."
+  },
+  {
+    "displayName": "Play Scala Hello World Tutorial",
+    "templateName": "play-samples-play-scala-hello-world-tutorial",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-scala-hello-world-tutorial",
+    "keywords": [
+      "play",
+      "scala",
+      "tutorial",
+      "hello-world",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-hello-world-tutorial",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-hello-world-tutorial",
+    "summary": "Play Hello World tutorial in Scala",
+    "description": "This tutorial introduces Play Framework, describes how Play web applications work, and walks you through steps to create page that displays a Hello World greeting.",
+    "featured": {
+      "play": 0
+    }
+  },
+  {
+    "displayName": "Play Java Hello World Tutorial",
+    "templateName": "play-samples-play-java-hello-world-tutorial",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-java-hello-world-tutorial",
+    "keywords": [
+      "play",
+      "java",
+      "tutorial",
+      "hello-world",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-java-hello-world-tutorial",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-hello-world-tutorial",
+    "summary": "Play Hello World tutorial in Java",
+    "description": "This tutorial introduces Play Framework, describes how Play web applications work, and walks you through steps to create page that displays a Hello World greeting."
+  },
+  {
+    "displayName": "Play Scala gRPC Example",
+    "templateName": "play-samples-play-scala-grpc-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-scala-grpc-example",
+    "keywords": [
+      "play",
+      "scala",
+      "grpc",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-grpc-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-scala-grpc-example",
+    "summary": "A starter application that shows how to use gRPC within a Play app.",
+    "description": "This is an example applicaiton shows how to use gRPC in Play.  Please see the documentation at <a href=\"https://developer.lightbend.com/guides/play-scala-grpc-example/\">https://developer.lightbend.com/guides/play-scala-grpc-example/</a> for more details."
+  },
+  {
+    "displayName": "Play Java gRPC Example",
+    "templateName": "play-samples-play-java-grpc-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.8.x/play-java-grpc-example",
+    "keywords": [
+      "play",
+      "java",
+      "grpc",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "play-java-grpc-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-samples-play-java-grpc-example",
+    "summary": "A starter application that shows how to use gRPC within a Play app.",
+    "description": "This is an example applicaiton shows how to use gRPC in Play.  Please see the documentation at <a href=\"https://developer.lightbend.com/guides/play-scala-grpc-example/\">https://developer.lightbend.com/guides/play-scala-grpc-example/</a> for more details."
+  },
+  {
+    "displayName": "Play Scala Seed",
+    "templateName": "play-scala-seed",
+    "gitHubRepo": "playframework/play-scala-seed.g8",
+    "gitHubUrl": "https://github.com/playframework/play-scala-seed.g8/tree/2.8.x",
+    "keywords": [
+      "scala",
+      "play",
+      "seed",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "",
+      "url": "git@github.com:playframework/play-scala-seed.g8.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-scala-seed",
+    "summary": "Play Scala Seed Project",
+    "description": "This is a seed project which creates a basic build for a Play application. It doesn't include a tutorial or demonstration, it's just a minimal project to start your own application from.",
+    "parameters": [
+      {
+        "type": "text",
+        "query": "name",
+        "displayName": "Project Name",
+        "defaultValue": "play-scala-seed",
+        "required": true,
+        "pattern": "[-A-Za-z0-9_.]+",
+        "format": "a sequence of letters, digits, minus sign, underscore, dot"
+      }
+    ]
+  },
+  {
+    "displayName": "Play Java Seed",
+    "templateName": "play-java-seed",
+    "gitHubRepo": "playframework/play-java-seed.g8",
+    "gitHubUrl": "https://github.com/playframework/play-java-seed.g8/tree/2.8.x",
+    "keywords": [
+      "java",
+      "play",
+      "seed",
+      "2.8.x"
+    ],
+    "source": {
+      "relativePath": "",
+      "url": "git@github.com:playframework/play-java-seed.g8.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.8.x"
+      }
+    },
+    "downloadUrl": "https://example.lightbend.com/v1/download/play-java-seed",
+    "summary": "Play Java Seed Project",
+    "description": "This is a seed project which creates a basic build for a Play application. It doesn't include a tutorial or demonstration, it's just a minimal project to start your own application from.",
+    "parameters": [
+      {
+        "type": "text",
+        "query": "name",
+        "displayName": "Project Name",
+        "defaultValue": "play-java-seed",
+        "required": true,
+        "pattern": "[-A-Za-z0-9_.]+",
+        "format": "a sequence of letters, digits, minus sign, underscore, dot"
+      }
+    ]
+  }
+]

--- a/conf/playSamples_2.9.x.json
+++ b/conf/playSamples_2.9.x.json
@@ -1,0 +1,673 @@
+[
+  {
+    "displayName": "Play Scala Dependency Injection using Macwire Example",
+    "templateName": "play-samples-play-scala-macwire-di-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-scala-macwire-di-example",
+    "keywords": [
+      "play",
+      "scala",
+      "macwire",
+      "di",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-macwire-di-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "Sample project for compile-time DI with Macwire"
+  },
+  {
+    "displayName": "Play Scala Compile Time Dependency Injection Example",
+    "templateName": "play-samples-play-scala-compile-di-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-scala-compile-di-example",
+    "keywords": [
+      "play",
+      "scala",
+      "di",
+      "scalatest",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-compile-di-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "Example Play Project using compile time dependency injection and Play WS with ScalaTest"
+  },
+  {
+    "displayName": "Play Java Compile Time Dependency Injection Example",
+    "templateName": "play-samples-play-java-compile-di-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-java-compile-di-example",
+    "keywords": [
+      "play",
+      "java",
+      "di",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-java-compile-di-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "Play application using compile time DI with Java API"
+  },
+  {
+    "displayName": "Play Java using Dagger 2 for Compile Time DI",
+    "templateName": "play-samples-play-java-dagger2-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-java-dagger2-example",
+    "keywords": [
+      "play",
+      "java",
+      "di",
+      "dagger2",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-java-dagger2-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "Play Application using Dagger 2 for Compile Time DI"
+  },
+  {
+    "displayName": "Play Java Chatroom using Websockets Example",
+    "templateName": "play-samples-play-java-chatroom-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-java-chatroom-example",
+    "keywords": [
+      "play",
+      "java",
+      "websocket",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-java-chatroom-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "A simple chatroom using Play and Websockets with the Java API.",
+    "description": "This is a simple chatroom using Play and Websockets with the Java API.<br>This project makes use of<a href=\"http://doc.akka.io/docs/akka/current/java/stream/stream-dynamic.html\">dynamic streams</a> from Akka Streams, notably <code>BroadcastHub</code> and <code>MergeHub</code>.  By <a href=\"http://doc.akka.io/docs/akka/current/java/stream/stream-dynamic.html#Dynamic_fan-in_and_fan-out_with_MergeHub_and_BroadcastHub\">combining MergeHub and BroadcastHub</a>, you can get publish/subscribe functionality."
+  },
+  {
+    "displayName": "Play Scala Chatroom using Websockets Example",
+    "templateName": "play-samples-play-scala-chatroom-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-scala-chatroom-example",
+    "keywords": [
+      "play",
+      "scala",
+      "websocket",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-chatroom-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "A simple chatroom using Play and Websockets with the Scala API.",
+    "description": "This is a simple chatroom using Play and Websockets with the Scala API.<br>This project makes use of<a href=\"http://doc.akka.io/docs/akka/current/scala/stream/stream-dynamic.html\">dynamic streams</a> from Akka Streams, notably <code>BroadcastHub</code> and <code>MergeHub</code>.  By <a href=\"http://doc.akka.io/docs/akka/current/scala/stream/stream-dynamic.html#Dynamic_fan-in_and_fan-out_with_MergeHub_and_BroadcastHub\">combining MergeHub and BroadcastHub</a>, you can get publish/subscribe functionality."
+  },
+  {
+    "displayName": "Play Java Streaming Example",
+    "templateName": "play-samples-play-java-streaming-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-java-streaming-example",
+    "keywords": [
+      "play",
+      "java",
+      "streaming",
+      "sse",
+      "comet",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-java-streaming-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "This is an example Play template that demonstrates Streaming with Server Sent Events or Comet, using Akka Streams."
+  },
+  {
+    "displayName": "Play Scala Streaming Example",
+    "templateName": "play-samples-play-scala-streaming-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-scala-streaming-example",
+    "keywords": [
+      "play",
+      "scala",
+      "streaming",
+      "sse",
+      "comet",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-streaming-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "This is an example Play template that demonstrates Streaming with Server Sent Events or Comet, using Akka Streams."
+  },
+  {
+    "displayName": "Play Java Websocket Example",
+    "templateName": "play-samples-play-java-websocket-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-java-websocket-example",
+    "keywords": [
+      "play",
+      "java",
+      "websocket",
+      "actor",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-java-websocket-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "An example Play application that shows how to use Play's Websocket API in Java, by showing a series of stock tickers updated using WebSocket.",
+    "description": "The Websocket API is built on Akka Streams, and so is async, non-blocking, and backpressure aware. Using Akka Streams also means that interacting with Akka Actors is simple.<br>There are also tests showing how Junit and Akka Testkit are used to test actors and flows."
+  },
+  {
+    "displayName": "Play Scala Websocket Example",
+    "templateName": "play-samples-play-scala-websocket-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-scala-websocket-example",
+    "keywords": [
+      "play",
+      "scala",
+      "websocket",
+      "actor",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-websocket-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "An example Play application that shows how to use Play's Websocket API in Scala, by showing a series of stock tickers updated using WebSocket.",
+    "description": "The Websocket API is built on Akka Streams, and so is async, non-blocking, and backpressure aware. Using Akka Streams also means that interacting with Akka Actors is simple.<br>There are also tests showing how Junit and Akka Testkit are used to test actors and flows."
+  },
+  {
+    "displayName": "Play Java File Upload Example",
+    "templateName": "play-samples-play-java-fileupload-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-java-fileupload-example",
+    "keywords": [
+      "play",
+      "java",
+      "upload",
+      "multipart",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-java-fileupload-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "A sample project that shows how to upload a file through Akka Streams using a custom BodyParser using Akka Streams using the Java API."
+  },
+  {
+    "displayName": "Play Scala File Upload Example",
+    "templateName": "play-samples-play-scala-fileupload-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-scala-fileupload-example",
+    "keywords": [
+      "play",
+      "scala",
+      "upload",
+      "multipart",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-fileupload-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "A sample project that shows how to upload a file through Akka Streams using a custom BodyParser using Akka Streams and the Scala API."
+  },
+  {
+    "displayName": "Play Scala Starter Example",
+    "templateName": "play-samples-play-scala-starter-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-scala-starter-example",
+    "keywords": [
+      "play",
+      "scala",
+      "starter",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-starter-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "A starter application that shows how Play works.",
+    "description": "This is a starter application that shows how Play works.  Please see the documentation at <a href=\"https://www.playframework.com/documentation/latest/Home\">https://www.playframework.com/documentation/latest/Home</a> for more details."
+  },
+  {
+    "displayName": "Play Java Starter Example",
+    "templateName": "play-samples-play-java-starter-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-java-starter-example",
+    "keywords": [
+      "play",
+      "java",
+      "starter",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-java-starter-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "A starter application that shows how Play works.",
+    "description": "This is a starter application that shows how Play works.  Please see the documentation at <a href=\"https://www.playframework.com/documentation/latest/Home\">https://www.playframework.com/documentation/latest/Home</a> for more details."
+  },
+  {
+    "displayName": "Play Scala Anorm Example",
+    "templateName": "play-samples-play-scala-anorm-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-scala-anorm-example",
+    "keywords": [
+      "play",
+      "scala",
+      "anorm",
+      "database",
+      "orm",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-anorm-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "An example Play application that uses Scala on the front end, and communicates with an in memory database using Anorm."
+  },
+  {
+    "displayName": "Play Java JPA Example",
+    "templateName": "play-samples-play-java-jpa-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-java-jpa-example",
+    "keywords": [
+      "play",
+      "java",
+      "jpa",
+      "hibernate",
+      "orm",
+      "database",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-java-jpa-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "This project demonstrate how to create a simple CRUD application with Play, using JPA."
+  },
+  {
+    "displayName": "Play Java Ebean Example",
+    "templateName": "play-samples-play-java-ebean-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-java-ebean-example",
+    "keywords": [
+      "play",
+      "java",
+      "ebean",
+      "database",
+      "orm",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-java-ebean-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "An example Play application that uses Java, and communicates with an in memory database using EBean."
+  },
+  {
+    "displayName": "Play Scala REST API Example",
+    "templateName": "play-samples-play-scala-rest-api-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-scala-rest-api-example",
+    "keywords": [
+      "play",
+      "scala",
+      "rest",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-rest-api-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "Example project for making a REST API in Play using the Scala API."
+  },
+  {
+    "displayName": "Play Java REST API Example",
+    "templateName": "play-samples-play-java-rest-api-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-java-rest-api-example",
+    "keywords": [
+      "play",
+      "java",
+      "rest",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-java-rest-api-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "Example project for making a REST API in Play using the Java API."
+  },
+  {
+    "displayName": "Play Scala Forms Example",
+    "templateName": "play-samples-play-scala-forms-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-scala-forms-example",
+    "keywords": [
+      "play",
+      "scala",
+      "forms",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-forms-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "Example project for doing forms processing in Play in the Scala API."
+  },
+  {
+    "displayName": "Play Java Forms Example",
+    "templateName": "play-samples-play-java-forms-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-java-forms-example",
+    "keywords": [
+      "play",
+      "java",
+      "forms",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-java-forms-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "Example project for doing forms processing in Play in the Java API."
+  },
+  {
+    "displayName": "Play Secure HTTP (SSL/TLS) Example",
+    "templateName": "play-samples-play-scala-tls-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-scala-tls-example",
+    "keywords": [
+      "play",
+      "scala",
+      "https",
+      "ssl",
+      "tls",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-tls-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "This application shows how to use Play with SSL/TLS, using the Java Secure Socket Extension (JSSE) API."
+  },
+  {
+    "displayName": "Play Scala Secure Session Example",
+    "templateName": "play-samples-play-scala-secure-session-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-scala-secure-session-example",
+    "keywords": [
+      "play",
+      "scala",
+      "kalium",
+      "encryption",
+      "session",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-secure-session-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "An example Play application showing encrypted session management",
+    "description": "This is an example application that shows how to use symmetric encryption with <a href=\"https://github.com/abstractj/kalium/\">Kalium</a></br>You must install libsodium before using this application.  If you have homebrew, you can use <code>brew install libsodium</code>."
+  },
+  {
+    "displayName": "Play Scala Hello World Tutorial",
+    "templateName": "play-samples-play-scala-hello-world-tutorial",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-scala-hello-world-tutorial",
+    "keywords": [
+      "play",
+      "scala",
+      "tutorial",
+      "hello-world",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-hello-world-tutorial",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "Play Hello World tutorial in Scala",
+    "description": "This tutorial introduces Play Framework, describes how Play web applications work, and walks you through steps to create page that displays a Hello World greeting.",
+    "featured": {
+      "play": 0
+    }
+  },
+  {
+    "displayName": "Play Java Hello World Tutorial",
+    "templateName": "play-samples-play-java-hello-world-tutorial",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-java-hello-world-tutorial",
+    "keywords": [
+      "play",
+      "java",
+      "tutorial",
+      "hello-world",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-java-hello-world-tutorial",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "Play Hello World tutorial in Java",
+    "description": "This tutorial introduces Play Framework, describes how Play web applications work, and walks you through steps to create page that displays a Hello World greeting."
+  },
+  {
+    "displayName": "Play Scala gRPC Example",
+    "templateName": "play-samples-play-scala-grpc-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-scala-grpc-example",
+    "keywords": [
+      "play",
+      "scala",
+      "grpc",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-grpc-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "A starter application that shows how to use gRPC within a Play app.",
+    "description": "This is an example applicaiton shows how to use gRPC in Play.  Please see the documentation at <a href=\"https://developer.lightbend.com/guides/play-scala-grpc-example/\">https://developer.lightbend.com/guides/play-scala-grpc-example/</a> for more details."
+  },
+  {
+    "displayName": "Play Java gRPC Example",
+    "templateName": "play-samples-play-java-grpc-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/2.9.x/play-java-grpc-example",
+    "keywords": [
+      "play",
+      "java",
+      "grpc",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "play-java-grpc-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "A starter application that shows how to use gRPC within a Play app.",
+    "description": "This is an example applicaiton shows how to use gRPC in Play.  Please see the documentation at <a href=\"https://developer.lightbend.com/guides/play-scala-grpc-example/\">https://developer.lightbend.com/guides/play-scala-grpc-example/</a> for more details."
+  },
+  {
+    "displayName": "Play Scala Seed",
+    "templateName": "play-scala-seed",
+    "gitHubRepo": "playframework/play-scala-seed.g8",
+    "gitHubUrl": "https://github.com/playframework/play-scala-seed.g8/tree/2.9.x",
+    "keywords": [
+      "scala",
+      "play",
+      "seed",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "",
+      "url": "git@github.com:playframework/play-scala-seed.g8.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "Play Scala Seed Project",
+    "description": "This is a seed project which creates a basic build for a Play application. It doesn't include a tutorial or demonstration, it's just a minimal project to start your own application from.",
+    "parameters": [
+      {
+        "type": "text",
+        "query": "name",
+        "displayName": "Project Name",
+        "defaultValue": "play-scala-seed",
+        "required": true,
+        "pattern": "[-A-Za-z0-9_.]+",
+        "format": "a sequence of letters, digits, minus sign, underscore, dot"
+      }
+    ]
+  },
+  {
+    "displayName": "Play Java Seed",
+    "templateName": "play-java-seed",
+    "gitHubRepo": "playframework/play-java-seed.g8",
+    "gitHubUrl": "https://github.com/playframework/play-java-seed.g8/tree/2.9.x",
+    "keywords": [
+      "java",
+      "play",
+      "seed",
+      "2.9.x"
+    ],
+    "source": {
+      "relativePath": "",
+      "url": "git@github.com:playframework/play-java-seed.g8.git",
+      "ref": {
+        "type": "branch",
+        "name": "2.9.x"
+      }
+    },
+    "summary": "Play Java Seed Project",
+    "description": "This is a seed project which creates a basic build for a Play application. It doesn't include a tutorial or demonstration, it's just a minimal project to start your own application from.",
+    "parameters": [
+      {
+        "type": "text",
+        "query": "name",
+        "displayName": "Project Name",
+        "defaultValue": "play-java-seed",
+        "required": true,
+        "pattern": "[-A-Za-z0-9_.]+",
+        "format": "a sequence of letters, digits, minus sign, underscore, dot"
+      }
+    ]
+  }
+]

--- a/conf/playSamples_3.0.x.json
+++ b/conf/playSamples_3.0.x.json
@@ -1,0 +1,673 @@
+[
+  {
+    "displayName": "Play Scala Dependency Injection using Macwire Example",
+    "templateName": "play-samples-play-scala-macwire-di-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-scala-macwire-di-example",
+    "keywords": [
+      "play",
+      "scala",
+      "macwire",
+      "di",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-macwire-di-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "Sample project for compile-time DI with Macwire"
+  },
+  {
+    "displayName": "Play Scala Compile Time Dependency Injection Example",
+    "templateName": "play-samples-play-scala-compile-di-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-scala-compile-di-example",
+    "keywords": [
+      "play",
+      "scala",
+      "di",
+      "scalatest",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-compile-di-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "Example Play Project using compile time dependency injection and Play WS with ScalaTest"
+  },
+  {
+    "displayName": "Play Java Compile Time Dependency Injection Example",
+    "templateName": "play-samples-play-java-compile-di-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-java-compile-di-example",
+    "keywords": [
+      "play",
+      "java",
+      "di",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-java-compile-di-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "Play application using compile time DI with Java API"
+  },
+  {
+    "displayName": "Play Java using Dagger 2 for Compile Time DI",
+    "templateName": "play-samples-play-java-dagger2-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-java-dagger2-example",
+    "keywords": [
+      "play",
+      "java",
+      "di",
+      "dagger2",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-java-dagger2-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "Play Application using Dagger 2 for Compile Time DI"
+  },
+  {
+    "displayName": "Play Java Chatroom using Websockets Example",
+    "templateName": "play-samples-play-java-chatroom-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-java-chatroom-example",
+    "keywords": [
+      "play",
+      "java",
+      "websocket",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-java-chatroom-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "A simple chatroom using Play and Websockets with the Java API.",
+    "description": "This is a simple chatroom using Play and Websockets with the Java API.<br>This project makes use of<a href=\"http://doc.akka.io/docs/akka/current/java/stream/stream-dynamic.html\">dynamic streams</a> from Akka Streams, notably <code>BroadcastHub</code> and <code>MergeHub</code>.  By <a href=\"http://doc.akka.io/docs/akka/current/java/stream/stream-dynamic.html#Dynamic_fan-in_and_fan-out_with_MergeHub_and_BroadcastHub\">combining MergeHub and BroadcastHub</a>, you can get publish/subscribe functionality."
+  },
+  {
+    "displayName": "Play Scala Chatroom using Websockets Example",
+    "templateName": "play-samples-play-scala-chatroom-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-scala-chatroom-example",
+    "keywords": [
+      "play",
+      "scala",
+      "websocket",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-chatroom-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "A simple chatroom using Play and Websockets with the Scala API.",
+    "description": "This is a simple chatroom using Play and Websockets with the Scala API.<br>This project makes use of<a href=\"http://doc.akka.io/docs/akka/current/scala/stream/stream-dynamic.html\">dynamic streams</a> from Akka Streams, notably <code>BroadcastHub</code> and <code>MergeHub</code>.  By <a href=\"http://doc.akka.io/docs/akka/current/scala/stream/stream-dynamic.html#Dynamic_fan-in_and_fan-out_with_MergeHub_and_BroadcastHub\">combining MergeHub and BroadcastHub</a>, you can get publish/subscribe functionality."
+  },
+  {
+    "displayName": "Play Java Streaming Example",
+    "templateName": "play-samples-play-java-streaming-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-java-streaming-example",
+    "keywords": [
+      "play",
+      "java",
+      "streaming",
+      "sse",
+      "comet",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-java-streaming-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "This is an example Play template that demonstrates Streaming with Server Sent Events or Comet, using Akka Streams."
+  },
+  {
+    "displayName": "Play Scala Streaming Example",
+    "templateName": "play-samples-play-scala-streaming-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-scala-streaming-example",
+    "keywords": [
+      "play",
+      "scala",
+      "streaming",
+      "sse",
+      "comet",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-streaming-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "This is an example Play template that demonstrates Streaming with Server Sent Events or Comet, using Akka Streams."
+  },
+  {
+    "displayName": "Play Java Websocket Example",
+    "templateName": "play-samples-play-java-websocket-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-java-websocket-example",
+    "keywords": [
+      "play",
+      "java",
+      "websocket",
+      "actor",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-java-websocket-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "An example Play application that shows how to use Play's Websocket API in Java, by showing a series of stock tickers updated using WebSocket.",
+    "description": "The Websocket API is built on Akka Streams, and so is async, non-blocking, and backpressure aware. Using Akka Streams also means that interacting with Akka Actors is simple.<br>There are also tests showing how Junit and Akka Testkit are used to test actors and flows."
+  },
+  {
+    "displayName": "Play Scala Websocket Example",
+    "templateName": "play-samples-play-scala-websocket-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-scala-websocket-example",
+    "keywords": [
+      "play",
+      "scala",
+      "websocket",
+      "actor",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-websocket-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "An example Play application that shows how to use Play's Websocket API in Scala, by showing a series of stock tickers updated using WebSocket.",
+    "description": "The Websocket API is built on Akka Streams, and so is async, non-blocking, and backpressure aware. Using Akka Streams also means that interacting with Akka Actors is simple.<br>There are also tests showing how Junit and Akka Testkit are used to test actors and flows."
+  },
+  {
+    "displayName": "Play Java File Upload Example",
+    "templateName": "play-samples-play-java-fileupload-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-java-fileupload-example",
+    "keywords": [
+      "play",
+      "java",
+      "upload",
+      "multipart",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-java-fileupload-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "A sample project that shows how to upload a file through Akka Streams using a custom BodyParser using Akka Streams using the Java API."
+  },
+  {
+    "displayName": "Play Scala File Upload Example",
+    "templateName": "play-samples-play-scala-fileupload-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-scala-fileupload-example",
+    "keywords": [
+      "play",
+      "scala",
+      "upload",
+      "multipart",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-fileupload-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "A sample project that shows how to upload a file through Akka Streams using a custom BodyParser using Akka Streams and the Scala API."
+  },
+  {
+    "displayName": "Play Scala Starter Example",
+    "templateName": "play-samples-play-scala-starter-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-scala-starter-example",
+    "keywords": [
+      "play",
+      "scala",
+      "starter",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-starter-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "A starter application that shows how Play works.",
+    "description": "This is a starter application that shows how Play works.  Please see the documentation at <a href=\"https://www.playframework.com/documentation/latest/Home\">https://www.playframework.com/documentation/latest/Home</a> for more details."
+  },
+  {
+    "displayName": "Play Java Starter Example",
+    "templateName": "play-samples-play-java-starter-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-java-starter-example",
+    "keywords": [
+      "play",
+      "java",
+      "starter",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-java-starter-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "A starter application that shows how Play works.",
+    "description": "This is a starter application that shows how Play works.  Please see the documentation at <a href=\"https://www.playframework.com/documentation/latest/Home\">https://www.playframework.com/documentation/latest/Home</a> for more details."
+  },
+  {
+    "displayName": "Play Scala Anorm Example",
+    "templateName": "play-samples-play-scala-anorm-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-scala-anorm-example",
+    "keywords": [
+      "play",
+      "scala",
+      "anorm",
+      "database",
+      "orm",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-anorm-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "An example Play application that uses Scala on the front end, and communicates with an in memory database using Anorm."
+  },
+  {
+    "displayName": "Play Java JPA Example",
+    "templateName": "play-samples-play-java-jpa-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-java-jpa-example",
+    "keywords": [
+      "play",
+      "java",
+      "jpa",
+      "hibernate",
+      "orm",
+      "database",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-java-jpa-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "This project demonstrate how to create a simple CRUD application with Play, using JPA."
+  },
+  {
+    "displayName": "Play Java Ebean Example",
+    "templateName": "play-samples-play-java-ebean-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-java-ebean-example",
+    "keywords": [
+      "play",
+      "java",
+      "ebean",
+      "database",
+      "orm",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-java-ebean-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "An example Play application that uses Java, and communicates with an in memory database using EBean."
+  },
+  {
+    "displayName": "Play Scala REST API Example",
+    "templateName": "play-samples-play-scala-rest-api-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-scala-rest-api-example",
+    "keywords": [
+      "play",
+      "scala",
+      "rest",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-rest-api-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "Example project for making a REST API in Play using the Scala API."
+  },
+  {
+    "displayName": "Play Java REST API Example",
+    "templateName": "play-samples-play-java-rest-api-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-java-rest-api-example",
+    "keywords": [
+      "play",
+      "java",
+      "rest",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-java-rest-api-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "Example project for making a REST API in Play using the Java API."
+  },
+  {
+    "displayName": "Play Scala Forms Example",
+    "templateName": "play-samples-play-scala-forms-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-scala-forms-example",
+    "keywords": [
+      "play",
+      "scala",
+      "forms",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-forms-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "Example project for doing forms processing in Play in the Scala API."
+  },
+  {
+    "displayName": "Play Java Forms Example",
+    "templateName": "play-samples-play-java-forms-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-java-forms-example",
+    "keywords": [
+      "play",
+      "java",
+      "forms",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-java-forms-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "Example project for doing forms processing in Play in the Java API."
+  },
+  {
+    "displayName": "Play Secure HTTP (SSL/TLS) Example",
+    "templateName": "play-samples-play-scala-tls-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-scala-tls-example",
+    "keywords": [
+      "play",
+      "scala",
+      "https",
+      "ssl",
+      "tls",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-tls-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "This application shows how to use Play with SSL/TLS, using the Java Secure Socket Extension (JSSE) API."
+  },
+  {
+    "displayName": "Play Scala Secure Session Example",
+    "templateName": "play-samples-play-scala-secure-session-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-scala-secure-session-example",
+    "keywords": [
+      "play",
+      "scala",
+      "kalium",
+      "encryption",
+      "session",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-secure-session-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "An example Play application showing encrypted session management",
+    "description": "This is an example application that shows how to use symmetric encryption with <a href=\"https://github.com/abstractj/kalium/\">Kalium</a></br>You must install libsodium before using this application.  If you have homebrew, you can use <code>brew install libsodium</code>."
+  },
+  {
+    "displayName": "Play Scala Hello World Tutorial",
+    "templateName": "play-samples-play-scala-hello-world-tutorial",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-scala-hello-world-tutorial",
+    "keywords": [
+      "play",
+      "scala",
+      "tutorial",
+      "hello-world",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-hello-world-tutorial",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "Play Hello World tutorial in Scala",
+    "description": "This tutorial introduces Play Framework, describes how Play web applications work, and walks you through steps to create page that displays a Hello World greeting.",
+    "featured": {
+      "play": 0
+    }
+  },
+  {
+    "displayName": "Play Java Hello World Tutorial",
+    "templateName": "play-samples-play-java-hello-world-tutorial",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-java-hello-world-tutorial",
+    "keywords": [
+      "play",
+      "java",
+      "tutorial",
+      "hello-world",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-java-hello-world-tutorial",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "Play Hello World tutorial in Java",
+    "description": "This tutorial introduces Play Framework, describes how Play web applications work, and walks you through steps to create page that displays a Hello World greeting."
+  },
+  {
+    "displayName": "Play Scala gRPC Example",
+    "templateName": "play-samples-play-scala-grpc-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-scala-grpc-example",
+    "keywords": [
+      "play",
+      "scala",
+      "grpc",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-scala-grpc-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "A starter application that shows how to use gRPC within a Play app.",
+    "description": "This is an example applicaiton shows how to use gRPC in Play.  Please see the documentation at <a href=\"https://developer.lightbend.com/guides/play-scala-grpc-example/\">https://developer.lightbend.com/guides/play-scala-grpc-example/</a> for more details."
+  },
+  {
+    "displayName": "Play Java gRPC Example",
+    "templateName": "play-samples-play-java-grpc-example",
+    "gitHubRepo": "playframework/play-samples",
+    "gitHubUrl": "https://github.com/playframework/play-samples/tree/3.0.x/play-java-grpc-example",
+    "keywords": [
+      "play",
+      "java",
+      "grpc",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "play-java-grpc-example",
+      "url": "git@github.com:playframework/play-samples.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "A starter application that shows how to use gRPC within a Play app.",
+    "description": "This is an example applicaiton shows how to use gRPC in Play.  Please see the documentation at <a href=\"https://developer.lightbend.com/guides/play-scala-grpc-example/\">https://developer.lightbend.com/guides/play-scala-grpc-example/</a> for more details."
+  },
+  {
+    "displayName": "Play Scala Seed",
+    "templateName": "play-scala-seed",
+    "gitHubRepo": "playframework/play-scala-seed.g8",
+    "gitHubUrl": "https://github.com/playframework/play-scala-seed.g8/tree/3.0.x",
+    "keywords": [
+      "scala",
+      "play",
+      "seed",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "",
+      "url": "git@github.com:playframework/play-scala-seed.g8.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "Play Scala Seed Project",
+    "description": "This is a seed project which creates a basic build for a Play application. It doesn't include a tutorial or demonstration, it's just a minimal project to start your own application from.",
+    "parameters": [
+      {
+        "type": "text",
+        "query": "name",
+        "displayName": "Project Name",
+        "defaultValue": "play-scala-seed",
+        "required": true,
+        "pattern": "[-A-Za-z0-9_.]+",
+        "format": "a sequence of letters, digits, minus sign, underscore, dot"
+      }
+    ]
+  },
+  {
+    "displayName": "Play Java Seed",
+    "templateName": "play-java-seed",
+    "gitHubRepo": "playframework/play-java-seed.g8",
+    "gitHubUrl": "https://github.com/playframework/play-java-seed.g8/tree/3.0.x",
+    "keywords": [
+      "java",
+      "play",
+      "seed",
+      "3.0.x"
+    ],
+    "source": {
+      "relativePath": "",
+      "url": "git@github.com:playframework/play-java-seed.g8.git",
+      "ref": {
+        "type": "branch",
+        "name": "3.0.x"
+      }
+    },
+    "summary": "Play Java Seed Project",
+    "description": "This is a seed project which creates a basic build for a Play application. It doesn't include a tutorial or demonstration, it's just a minimal project to start your own application from.",
+    "parameters": [
+      {
+        "type": "text",
+        "query": "name",
+        "displayName": "Project Name",
+        "defaultValue": "play-java-seed",
+        "required": true,
+        "pattern": "[-A-Za-z0-9_.]+",
+        "format": "a sequence of letters, digits, minus sign, underscore, dot"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
It's just used to display/link the "Play Hello World Projects" under "Try the Hello World Tutorial" in https://www.playframework.com/getting-started
The service was down a couple of days ago, which meant _our_ website was giving 500 server errors.
Also we should no longer depend on Lightbend just to display two hello world project we host in our own GitHub organization anyway.

I just scrapped the JSON that is coming in currently from the service and saved it as json files.
We could of course also parse the play-samples repo and create that json files ourselves, e.g. we could add meta data files to the samples repo in each folder we read. However, no priority right now.