### PR TITLE
Upgrade sbt-web plugins

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.1")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-digest" % "1.1.4")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-gzip"   % "1.0.2")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-stylus" % "1.1.0")
+addSbtPlugin("com.github.sbt"    % "sbt-digest" % "2.0.0")
+addSbtPlugin("com.github.sbt"    % "sbt-gzip"   % "2.0.0")
+addSbtPlugin("com.github.sbt"    % "sbt-stylus" % "2.0.0")


### PR DESCRIPTION
* https://github.com/sbt/sbt-stylus/releases/tag/2.0.0
* https://github.com/sbt/sbt-digest/releases/tag/2.0.0
* https://github.com/sbt/sbt-gzip/releases/tag/2.0.0

They all uses latest sbt-web 1.5 / sbt-js-engine 1.3.x now, but most importantly are now hosted on maven central intead of deprecated https://repo.scala-sbt.org/ (see https://github.com/sbt/sbt/issues/7202)

Tested locally and the assets from this project are generated 1:1 like before.