### PR TITLE
Add Algolia docsearch metadata

### DIFF
--- a/app/views/documentation/header.scala.html
+++ b/app/views/documentation/header.scala.html
@@ -1,7 +1,7 @@
 @import controllers.documentation.ReverseRouter
 @(page: String, maybeContext: Option[models.documentation.TranslationContext] = None)(content: Html)(implicit req: RequestHeader, reverseRouter: ReverseRouter)
 
-@main(page, "documentation") {
+@main(page, "documentation", maybeContext) {
 
     <header id="top">
         <div class="wrapper">

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -1,5 +1,5 @@
 @import controllers.documentation.ReverseRouter
-@(title: String, scope: String = "home")(content: Html)(implicit req: RequestHeader, reverseRouter: ReverseRouter)
+@(title: String, scope: String = "home", maybeContext: Option[models.documentation.TranslationContext] = None)(content: Html)(implicit req: RequestHeader, reverseRouter: ReverseRouter)
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -21,6 +21,13 @@
 
         <meta name="globalsign-domain-verification" content="wISFsU3SjLaCmI4hF3fuBebFOs4shuuBnKV7fGALYz" />
         <meta name="google-site-verification" content="9oxXjOc4jWfnf21Iep-0dc2sDawa14s-Gpwho_yb5AU" />
+
+        @maybeContext.map { context =>
+            @for(version <- context.version) {
+                <meta name="docsearch:version" content="@{version.name}" />
+            }
+            <meta name="docsearch:tags" content="@{context.lang.language}" />
+        }
 
         <!-- OneTrust Cookies Consent Notice (Production Standard, playframework.com, en-GB) start -->
         <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="f6af8492-c939-49d1-98d9-0b5cde6ce6d2" ></script>


### PR DESCRIPTION
Current search was using DocSearch v2, which is legacy and looks like was self hosted by Lightbend (?)
v2 is legacy and not supported anymore.
DocSearch v3 needs some changes and is hosted by Aloglia for free now, unfortunately I do not have access to old docsearch config...

Need to implement faceting different than in v2 now (used to filter search results based on version like 2.8.x, 2.9.x 3.0.x, etc.)
- https://www.algolia.com/doc/guides/managing-results/refine-results/faceting/?client=javascript
- https://docsearch.algolia.com/docs/record-extractor/#indexing-content-for-faceting
- https://docsearch.algolia.com/docs/required-configuration/#introduce-global-information-as-meta-tags

Testing things locally for a bit just in case you are wondering what I am doing.