### PR TITLE
(Hidden) link to each doc 'Home' page from all releases page

### DIFF
--- a/app/assets/css/pages/_all-releases.styl
+++ b/app/assets/css/pages/_all-releases.styl
@@ -137,3 +137,6 @@
         font-size: 12px
         margin-top: 1em
         line-height: 58px;
+
+    tr.release .doclink
+        display: none

--- a/app/views/allreleases.scala.html
+++ b/app/views/allreleases.scala.html
@@ -5,11 +5,12 @@
   @if(release.secureUrl) {
     <td width="250">
       <a href="@release.secureUrl.get" class="@linkClass" data-version="@{release.version}">play-@{release.version}.zip</a>
+      @if(versionAtLeast(release.version, "2.0")){<a class="doclink" href="https://www.playframework.com/documentation/@{release.version}/Home">docs</a>}else{}
     </td>
     <td width="200">@release.date</td>
     <td width="100">@release.size.get</td>
   } else {
-    <td width="250">Play @release.version</td>
+    <td width="250">Play @release.version@if(versionAtLeast(release.version, "2.0")){<a class="doclink" href="https://www.playframework.com/documentation/@{release.version}/Home">docs</a>}else{}</td>
     <td width="200">@release.date</td>
     <td width="100"></td>
   }


### PR DESCRIPTION
This way all releases (2.0.0, 2.0.x,.... ,2.9.0, 2.9.1, ..., 2.9.x) will be crawled automatically. Also this has the advantage that when we cut a new release it will automatically be crawled without configuring anything in the Algolia crawler.
So we can make this page the entry point for crawling the docs and we should be good.
The links will be hidden.