### PR TITLE
Switch to new Algolia search index

### DIFF
--- a/app/views/documentation/algolia.scala.html
+++ b/app/views/documentation/algolia.scala.html
@@ -8,6 +8,7 @@ docsearch({
     indexName: 'playframework',
     inputSelector: '#search-input',
     algoliaOptions: {
+        hitsPerPage: 10,
         'facetFilters': [
             @for(version <- context.version) {
               "version: @{version.name}",

--- a/app/views/documentation/algolia.scala.html
+++ b/app/views/documentation/algolia.scala.html
@@ -3,7 +3,8 @@
 <script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.js"></script>
 @views.html.helper.script(Symbol("type") -> "text/javascript") {
 docsearch({
-    apiKey: 'a0b34e68c804cf96e76adcb02d47159b',
+    apiKey: '3a5278088008947c54a733e069ff82af',
+    appId: 'TCZHH5O33A',
     indexName: 'playframework',
     inputSelector: '#search-input',
     algoliaOptions: {


### PR DESCRIPTION
I had to setup a new Algolia account with a new index with new configuration because no one was able to restore the current acount/settings. There were much more problems to solve... Actually even if we could restore the current account we would have to upgrade it to latest Algolia docsearch v3 (was v1). So I had to set up a new Docsearch index with the new crawler v3. In the UI we keep using docsearch v1 because fortunately it's still compatible with index/crawler v3. I didn't know that so I first tried to replace the UI library with the new docsearch v3 UI, however this was a pain because it does only work correctly within a modal but not with our current doc page style with a dropdown... So I was spending way too many hours with bs before I chatted with the Algolia people in their Discord which helped me to make v3 index compatible with v1 docsearch UI. And there were other problems to solve... (got `null`s for certain search records, took me hours to figure out what's going on, etc...) So in the end it works now and I learned a lot at least, but I am just happy this is done now.

Also: New Play releases in the current doc setup will now be crawled automatically (once per week, but also possible to trigger manually), because we now use the releases page as entry point:
- #581

I have no idea how this was configured before, probably someone added an entry page for each new release so Algolia starts to crawl it...

Other related PRs for the new crawler config:
- #580 (Actually I have no idea how this was solved before without this attributes. Again I think someone added the versions face attributes manually after each release, which of course is a bit cumbersome. Now it's done automatically.)
- #582

Also, I tweaked the search ranking a bit and think it gives a bit better results now, but we can alway improve the ranking. IMHO search now behave quite the same then with the old index.

<details>
  <summary>Here is the current Algolia crawler config (which also sets up the index on first crawl via `initialIndexSettings`</summary>
  
```js
new Crawler({
  appId: "TCZHH5O33A",
  apiKey: "XXX_SECRET_XXX",
  maxUrls: 1000000,
  indexPrefix: "",
  rateLimit: 8,
  renderJavaScript: false,
  startUrls: ["https://www.playframework.com/releases"],
  discoveryPatterns: [
    "https://www.playframework.com/documentation/[2-9].\\d.(\\d|x)/**",
  ],
  schedule: "at 16:20 on Tuesday",
  maxDepth: 10,
  actions: [
    {
      indexName: "playframework",
      pathsToMatch: [
        "https://www.playframework.com/documentation/[2-9].\\d.(\\d|x)/**",
      ],
      recordExtractor: ({ $, helpers }) => {
        // Remove elements from page we do not want to crawl
        $("div#version-header").remove();
        $("form#search").remove();
        $("ol#breadcrumb").remove();
        $("p#contribute-to-docs").remove();
        $(
          "body > section#content > article > blockquote:contains('Next:')",
        ).remove();

        //$("meta[name='docsearch:tags']").attr("content")

        return helpers.docsearch({
          recordProps: {
            lvl0: {
              selectors: "body > section#content > article > h1",
              defaultValue: "Documentation",
            },
            lvl1: [
              "body > section#content > article > h2",
              //"body > section#content > article > h1",
            ],
            lvl2: [
              "body > section#content > article > h3",
              //"body > section#content > article > h2",
              //"body > section#content > article > h1",
            ],
            content: [
              "body > section#content > article > p",
              "body > section#content > article > ul",
              "body > section#content > article > ol",
              "body > section#content > article > blockquote",
              // code blocks:
              //"body > section#content > article > pre",
              //"body > section#content > article > dl",
            ],
          },
          aggregateContent: true,
          recordVersion: "v3",
        });
      },
    },
  ],
  initialIndexSettings: {
    playframework: {
      advancedSyntax: true,
      allowTyposOnNumericTokens: false,
      attributeCriteriaComputedByMinProximity: true,
      attributeForDistinct: "url",
      attributesForFaceting: ["lang", "version", "tags"],
      attributesToHighlight: ["hierarchy", "content"],
      attributesToRetrieve: ["hierarchy", "content", "anchor", "url"],
      attributesToSnippet: ["content:10"],
      camelCaseAttributes: ["hierarchy", "content"],
      customRanking: [
        "desc(weight.pageRank)",
        "desc(weight.level)",
        "asc(weight.position)",
      ],
      distinct: 1,
      highlightPostTag: "</span>",
      highlightPreTag: '<span class="algolia-docsearch-suggestion--highlight">',
      ignorePlurals: true,
      minProximity: 1,
      minWordSizefor1Typo: 3,
      minWordSizefor2Typos: 7,
      ranking: [
        "exact",
        "proximity",
        "words",
        "filters",
        "typo",
        "attribute",
        "custom",
      ],
      removeWordsIfNoResults: "allOptional",
      searchableAttributes: ["content"],
    },
  },
  ignoreCanonicalTo: false,
  safetyChecks: { beforeIndexPublishing: { maxLostRecordsPercentage: 10 } },
  exclusionPatterns: [
    "https://www.playframework.com/documentation/[2-9].\\d.(\\d|x)/api/**",
  ],
});
```
</details>