### PR TITLE
Do not display version info on doc pages

### DIFF
--- a/app/views/documentation/v2.scala.html
+++ b/app/views/documentation/v2.scala.html
@@ -19,7 +19,9 @@
 
     <article>
         @content.map { html =>
-            @versionInfo(pageFileName)(messages, context, reverseRouter)
+            @if(!req.headers.get(play.api.http.HeaderNames.USER_AGENT).exists(_.toLowerCase.startsWith("algolia crawler"))) {
+                @versionInfo(pageFileName)(messages, context, reverseRouter)
+            }
 
             @for(version <- context.version) {
                 <form id="search">


### PR DESCRIPTION
Do **not** show when the Algolia crawler visits.
<kbd><img width="670" src="https://github.com/playframework/playframework.com/assets/644927/0bfc4ebb-8aea-4492-8af0-2e089a43f4e2" /></kbd>


See
- https://github.com/playframework/playframework.com/issues/562
- https://support.algolia.com/hc/en-us/articles/17223760387857-What-is-the-user-agent-of-the-Crawler

Tested locally with curl by changing the `User-Agent` header.