### PR TITLE
fix `auto insertion` warnings

### DIFF
--- a/app/actors/DocumentationActor.scala
+++ b/app/actors/DocumentationActor.scala
@@ -561,7 +561,7 @@ class DocumentationActor(
         case GetSitemap(replyTo) =>
           sitemapGenerator
             .ask[Sitemap](replyTo => GenerateSitemap(documentation, replyTo))
-            .map(DocumentationSitemap)
+            .map(DocumentationSitemap.apply)
             .pipeTo(replyTo.toClassic)
           Behaviors.same
       }

--- a/app/controllers/documentation/DocumentationController.scala
+++ b/app/controllers/documentation/DocumentationController.scala
@@ -261,7 +261,7 @@ class DocumentationController @Inject() (
    * - Otherwise, we redirect them to the latest for the default language.
    */
   def latest(lang: Option[Lang], path: String) = DocsAction { actor =>
-    (actor ? GetSummary).mapTo[DocumentationSummary].map { summary =>
+    (actor ? GetSummary.apply).mapTo[DocumentationSummary].map { summary =>
       val (selectedLang, version) = lang match {
         // requested the default lang
         case Some(l) if l == summary.defaultLang => None -> summary.defaultLatest
@@ -290,7 +290,7 @@ class DocumentationController @Inject() (
     summary.translations.contains(lang) && summary.translations(lang) == summary.defaultLatest
 
   def sitemap = DocsAction { actor =>
-    (actor ? GetSitemap).mapTo[DocumentationSitemap].map { docSitemap =>
+    (actor ? GetSitemap.apply).mapTo[DocumentationSitemap].map { docSitemap =>
       Ok(docSitemap.sitemap.toXml)
     }
   }


### PR DESCRIPTION
```
[warn] -- Warning: /home/runner/work/playframework.com/playframework.com/app/actors/DocumentationActor.scala:564:17 
[warn] 564 |            .map(DocumentationSitemap)
[warn]     |                 ^^^^^^^^^^^^^^^^^^^^
[warn]     |The method `apply` is inserted. The auto insertion will be deprecated, please write `actors.DocumentationActor.DocumentationSitemap.apply` explicitly.
[warn] -- Warning: /home/runner/work/playframework.com/playframework.com/app/controllers/documentation/DocumentationController.scala:2[64](https://github.com/playframework/playframework.com/actions/runs/16085402790/job/45395893285#step:12:65):13 
[warn] 264 |    (actor ? GetSummary).mapTo[DocumentationSummary].map { summary =>
[warn]     |             ^^^^^^^^^^
[warn]     |The method `apply` is inserted. The auto insertion will be deprecated, please write `actors.DocumentationActor.GetSummary.apply` explicitly.
[warn] -- Warning: /home/runner/work/playframework.com/playframework.com/app/controllers/documentation/DocumentationController.scala:293:13 
[warn] 293 |    (actor ? GetSitemap).mapTo[DocumentationSitemap].map { docSitemap =>
[warn]     |             ^^^^^^^^^^
[warn]     |The method `apply` is inserted. The auto insertion will be deprecated, please write `actors.DocumentationActor.GetSitemap.apply` explicitly.
```