### PR TITLE
Fix warning

### DIFF
--- a/app/models/modules/Module.scala
+++ b/app/models/modules/Module.scala
@@ -30,7 +30,7 @@ object Module {
         (__ \ "versions").write[Seq[Release]]
     ).apply(m => (m._1.name, m._1.fullname, m._2))
 
-    (__ \ "modules").write(using Writes.iterableWrites[(Module, Seq[Release]), Seq])
+    (__ \ "modules").write(using Writes.iterableWrites2[(Module, Seq[Release]), Seq[(Module, Seq[Release])]])
   }
 }
 


### PR DESCRIPTION

https://github.com/playframework/play-json/blob/a8ace0633c57ae7dd830cfbd61b8253144eb4cba/play-json/shared/src/main/scala/play/api/libs/json/Writes.scala#L515-L527

```
[warn] -- Deprecation Warning: /home/runner/work/playframework.com/playframework.com/app/models/modules/Module.scala:33:40 
[warn] 33 |    (__ \ "modules").write(using Writes.iterableWrites[(Module, Seq[Release]), Seq])
[warn]    |                                 ^^^^^^^^^^^^^^^^^^^^^
[warn]    |method iterableWrites in trait LowPriorityWrites is deprecated since 2.8.1: Use `iterableWrites2`
```

